### PR TITLE
fix explosion block desync

### DIFF
--- a/core/src/main/java/nl/matsv/viabackwards/protocol/protocol1_13_2to1_14/Protocol1_13_2To1_14.java
+++ b/core/src/main/java/nl/matsv/viabackwards/protocol/protocol1_13_2to1_14/Protocol1_13_2To1_14.java
@@ -48,7 +48,6 @@ public class Protocol1_13_2To1_14 extends BackwardsProtocol {
         registerOutgoing(State.PLAY, 0x1A, 0x1B);
         registerOutgoing(State.PLAY, 0x1B, 0x1C);
         registerOutgoing(State.PLAY, 0x54, 0x1D);
-        registerOutgoing(State.PLAY, 0x1C, 0x1E);
         registerOutgoing(State.PLAY, 0x1E, 0x20);
         registerOutgoing(State.PLAY, 0x20, 0x21);
 

--- a/core/src/main/java/nl/matsv/viabackwards/protocol/protocol1_13_2to1_14/packets/BlockItemPackets1_14.java
+++ b/core/src/main/java/nl/matsv/viabackwards/protocol/protocol1_13_2to1_14/packets/BlockItemPackets1_14.java
@@ -483,6 +483,30 @@ public class BlockItemPackets1_14 extends BlockItemRewriter<Protocol1_13_2To1_14
             }
         });
 
+        //Explosion
+        protocol.registerOutgoing(State.PLAY, 0x1C, 0x1E, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.FLOAT); // X
+                map(Type.FLOAT); // Y
+                map(Type.FLOAT); // Z
+                map(Type.FLOAT); // Radius
+                handler(new PacketHandler() {
+                    @Override
+                    public void handle(PacketWrapper wrapper) throws Exception {
+                        for (int i = 0; i < 3; i++) {
+                            float coord = wrapper.get(Type.FLOAT, i);
+
+                            if (coord < 0f) {
+                                coord = (float) Math.floor(coord);
+                                wrapper.set(Type.FLOAT, i, coord);
+                            }
+                        }
+                    }
+                });
+            }
+        });
+
         //Chunk
         protocol.registerOutgoing(State.PLAY, 0x21, 0x22, new PacketRemapper() {
             @Override


### PR DESCRIPTION
Since 1.14 Minecraft calculates the explosion origin differently. The coordinates are are now floor(x) instead of int(x). We need to adjust negative coordinates so that the client rounds to the same number as the server would expect it.