### PR TITLE
Don't assume CanPlaceOn tag is ListTag

### DIFF
--- a/core/src/main/java/nl/matsv/viabackwards/protocol/protocol1_12_2to1_13/packets/BlockItemPackets1_13.java
+++ b/core/src/main/java/nl/matsv/viabackwards/protocol/protocol1_12_2to1_13/packets/BlockItemPackets1_13.java
@@ -625,6 +625,8 @@ public class BlockItemPackets1_13 extends nl.matsv.viabackwards.api.rewriters.It
     }
 
     private void rewriteCanPlaceToClient(CompoundTag tag, String tagName) {
+        // The tag was manually created incorrectly so ignore rewriting it
+        if (!(tag.get(tagName) instanceof ListTag)) return;
         ListTag blockTag = tag.get(tagName);
         if (blockTag == null) return;
 
@@ -865,6 +867,7 @@ public class BlockItemPackets1_13 extends nl.matsv.viabackwards.api.rewriters.It
     }
 
     private void rewriteCanPlaceToServer(CompoundTag tag, String tagName) {
+        if (!(tag.get(tagName) instanceof ListTag)) return;
         ListTag blockTag = tag.remove(extraNbtTag + "|" + tagName);
         if (blockTag != null) {
             tag.put(ConverterRegistry.convertToTag(tagName, ConverterRegistry.convertToValue(blockTag)));


### PR DESCRIPTION
I guess somewhere in my testing I made a CanPlaceOn tag that had a byte value and the client disconnected on me when I put ViaBackwards on my testing instance. This commit doesn't translate the CanPlaceOn tag if it isn't a ListTag.