### PR TITLE
Fix mushrooms blocks on 1.12.2 and below

### DIFF
--- a/common/src/main/java/nl/matsv/viabackwards/protocol/protocol1_12_2to1_13/data/BackwardsMappings.java
+++ b/common/src/main/java/nl/matsv/viabackwards/protocol/protocol1_12_2to1_13/data/BackwardsMappings.java
@@ -108,8 +108,20 @@ public class BackwardsMappings extends nl.matsv.viabackwards.api.data.BackwardsM
 
     @Override
     protected int checkValidity(int id, int mappedId, String type) {
-        // Don't warn for missing ids here
-        return mappedId;
+        switch (mappedId) {
+            // https://github.com/ViaVersion/ViaBackwards/issues/290
+            case 1595:
+            case 1596:
+            case 1597:
+                return 1584; // brown mushroom block
+            case 1611:
+            case 1612:
+            case 1613:
+                return 1600; // red mushroom block
+            default:
+                // Don't warn for missing ids here
+                return mappedId;
+        }
     }
 
     @Override

--- a/common/src/main/java/nl/matsv/viabackwards/protocol/protocol1_12_2to1_13/data/BackwardsMappings.java
+++ b/common/src/main/java/nl/matsv/viabackwards/protocol/protocol1_12_2to1_13/data/BackwardsMappings.java
@@ -107,9 +107,11 @@ public class BackwardsMappings extends nl.matsv.viabackwards.api.data.BackwardsM
     }
 
     @Override
-    protected int checkValidity(int id, int mappedId, String type) {
+    public int getNewBlockStateId(int id) {
+        int mappedId = super.getNewBlockStateId(id);
+
+        // https://github.com/ViaVersion/ViaBackwards/issues/290
         switch (mappedId) {
-            // https://github.com/ViaVersion/ViaBackwards/issues/290
             case 1595:
             case 1596:
             case 1597:
@@ -119,9 +121,14 @@ public class BackwardsMappings extends nl.matsv.viabackwards.api.data.BackwardsM
             case 1613:
                 return 1600; // red mushroom block
             default:
-                // Don't warn for missing ids here
                 return mappedId;
         }
+    }
+
+    @Override
+    protected int checkValidity(int id, int mappedId, String type) {
+        // Don't warn for missing ids here
+        return mappedId;
     }
 
     @Override


### PR DESCRIPTION
This fixes mushrooms blocks not showing on 1.12.2 and below, like in #290 (fixes #290).

Looks like fore some reasons the mushrooms blocks with id `99` or `100` and with data `11`, `12` or `13` are not displayed by the client. I wasn't sure if it's an issue or not with the ViaVersion mappings so I just added this switch to fix the issue, but if you prefer I can open a PR in the ViaVersion repo to remove these 6 mappings.