### PR TITLE
1.16.4 -> 1.17 PING handler

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/Protocol1_16_4To1_17.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/Protocol1_16_4To1_17.java
@@ -188,6 +188,8 @@ public final class Protocol1_16_4To1_17 extends BackwardsProtocol<ClientboundPac
 
                     // Plugins expecting a real response will have to handle this accordingly themselves
                     PacketWrapper pongPacket = wrapper.create(ServerboundPackets1_17.PONG);
+                    // We still need to write the packet data, so let's assume the id 0
+                    pongPacket.write(Type.INT, 0);
                     pongPacket.sendToServer(Protocol1_16_4To1_17.class);
                 });
             }

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/Protocol1_16_4To1_17.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/Protocol1_16_4To1_17.java
@@ -187,9 +187,9 @@ public final class Protocol1_16_4To1_17 extends BackwardsProtocol<ClientboundPac
                     wrapper.cancel();
 
                     // Plugins expecting a real response will have to handle this accordingly themselves
+                    int id = wrapper.read(Type.INT);
                     PacketWrapper pongPacket = wrapper.create(ServerboundPackets1_17.PONG);
-                    // We still need to write the packet data, so let's assume the id 0
-                    pongPacket.write(Type.INT, 0);
+                    pongPacket.write(Type.INT, id);
                     pongPacket.sendToServer(Protocol1_16_4To1_17.class);
                 });
             }


### PR DESCRIPTION
The server expects this packet to have an int id.
You can see this int being read in ViaVersion [here](https://github.com/ViaVersion/ViaVersion/blob/4074352a531cfb0de6fa81e043ee761737748a7a/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_17to1_16_4/packets/InventoryPackets.java#L121).

I came across this bug when I tried to join a 1.8 server using ViaVersion with my client (which uses ViaFabric and because of that ViaBackwards) on 1.17. I got kicked immediately because the Pong packet is missing its data, which I added here.