### PR TITLE
Window confirmation packet for legacy support of 1.17 Ping/Pong

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/Protocol1_16_4To1_17.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/Protocol1_16_4To1_17.java
@@ -184,9 +184,12 @@ public final class Protocol1_16_4To1_17 extends BackwardsProtocol<ClientboundPac
             public void registerMap() {
                 handler(wrapper -> {
                     int id = wrapper.read(Type.INT);
-                    wrapper.write(Type.UNSIGNED_BYTE, (short) 0);
-                    wrapper.write(Type.SHORT, (short) id);
-                    wrapper.write(Type.BOOLEAN, false);
+                    short cast = (short) id;
+                    if(id == cast) { // Do not send ping if the ID cannot be preserved
+                        wrapper.write(Type.UNSIGNED_BYTE, (short) 0);
+                        wrapper.write(Type.SHORT, cast);
+                        wrapper.write(Type.BOOLEAN, false);
+                    } else wrapper.cancel();
                 });
             }
         });

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/packets/BlockItemPackets1_17.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/packets/BlockItemPackets1_17.java
@@ -92,7 +92,6 @@ public final class BlockItemPackets1_17 extends ItemRewriter<Protocol1_16_4To1_1
                 });
             }
         });
-        protocol.cancelServerbound(ServerboundPackets1_16_2.WINDOW_CONFIRMATION);
 
         protocol.registerClientbound(ClientboundPackets1_17.SPAWN_PARTICLE, new PacketRemapper() {
             @Override


### PR DESCRIPTION
The window confirmation packets are removed in the 1.17 protocol and have been replaced with the ping/pong packets. The behaviour is the same if the window ID is set to 0 and the accepted status is set to false when it is sent to the client. 