### PR TITLE
Map smoke directions from 1.13.1 to 1.13

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_13to1_13_1/Protocol1_13To1_13_1.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_13to1_13_1/Protocol1_13To1_13_1.java
@@ -26,8 +26,6 @@ import com.viaversion.viabackwards.protocol.protocol1_13to1_13_1.packets.EntityP
 import com.viaversion.viabackwards.protocol.protocol1_13to1_13_1.packets.InventoryPackets1_13_1;
 import com.viaversion.viabackwards.protocol.protocol1_13to1_13_1.packets.WorldPackets1_13_1;
 import com.viaversion.viaversion.api.connection.UserConnection;
-import com.viaversion.viaversion.api.minecraft.BlockFace;
-import com.viaversion.viaversion.api.minecraft.Position;
 import com.viaversion.viaversion.api.minecraft.RegistryType;
 import com.viaversion.viaversion.api.minecraft.entities.Entity1_13Types;
 import com.viaversion.viaversion.api.minecraft.item.Item;
@@ -217,45 +215,6 @@ public class Protocol1_13To1_13_1 extends BackwardsProtocol<ClientboundPackets1_
                             int arrayLength = wrapper.passthrough(Type.VAR_INT);
                             for (int array = 0; array < arrayLength; array++) {
                                 wrapper.passthrough(Type.STRING_ARRAY); // String array
-                            }
-                        }
-                    }
-                });
-            }
-        });
-
-        registerClientbound(ClientboundPackets1_13.EFFECT, new PacketRemapper() {
-            @Override
-            public void registerMap() {
-                map(Type.INT); // Effect Id
-                map(Type.POSITION); // Location
-                map(Type.INT); // Data
-                handler(new PacketHandler() {
-                    @Override
-                    public void handle(PacketWrapper wrapper) throws Exception {
-                        int id = wrapper.get(Type.INT, 0);
-                        if (id == 2000) { // Smoke
-                            int data = wrapper.get(Type.INT, 1);
-                            switch (data) {
-                                case 0: // Down
-                                case 1: // Up
-                                    Position pos = wrapper.get(Type.POSITION, 0);
-                                    BlockFace relative = data == 0 ? BlockFace.BOTTOM : BlockFace.TOP;
-                                    wrapper.set(Type.POSITION, 0, pos.getRelative(relative)); // Y Offset
-                                    wrapper.set(Type.INT, 1, 4); // Self
-                                    break;
-                                case 2: // North
-                                    wrapper.set(Type.INT, 1, 1); // North
-                                    break;
-                                case 3: // South
-                                    wrapper.set(Type.INT, 1, 7); // South
-                                    break;
-                                case 4: // West
-                                    wrapper.set(Type.INT, 1, 3); // West
-                                    break;
-                                case 5: // East
-                                    wrapper.set(Type.INT, 1, 5); // East
-                                    break;
                             }
                         }
                     }

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_13to1_13_1/Protocol1_13To1_13_1.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_13to1_13_1/Protocol1_13To1_13_1.java
@@ -26,6 +26,8 @@ import com.viaversion.viabackwards.protocol.protocol1_13to1_13_1.packets.EntityP
 import com.viaversion.viabackwards.protocol.protocol1_13to1_13_1.packets.InventoryPackets1_13_1;
 import com.viaversion.viabackwards.protocol.protocol1_13to1_13_1.packets.WorldPackets1_13_1;
 import com.viaversion.viaversion.api.connection.UserConnection;
+import com.viaversion.viaversion.api.minecraft.BlockFace;
+import com.viaversion.viaversion.api.minecraft.Position;
 import com.viaversion.viaversion.api.minecraft.RegistryType;
 import com.viaversion.viaversion.api.minecraft.entities.Entity1_13Types;
 import com.viaversion.viaversion.api.minecraft.item.Item;
@@ -215,6 +217,45 @@ public class Protocol1_13To1_13_1 extends BackwardsProtocol<ClientboundPackets1_
                             int arrayLength = wrapper.passthrough(Type.VAR_INT);
                             for (int array = 0; array < arrayLength; array++) {
                                 wrapper.passthrough(Type.STRING_ARRAY); // String array
+                            }
+                        }
+                    }
+                });
+            }
+        });
+
+        registerClientbound(ClientboundPackets1_13.EFFECT, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.INT); // Effect Id
+                map(Type.POSITION); // Location
+                map(Type.INT); // Data
+                handler(new PacketHandler() {
+                    @Override
+                    public void handle(PacketWrapper wrapper) throws Exception {
+                        int id = wrapper.get(Type.INT, 0);
+                        if (id == 2000) { // Smoke
+                            int data = wrapper.get(Type.INT, 1);
+                            switch (data) {
+                                case 0: // Down
+                                case 1: // Up
+                                    Position pos = wrapper.get(Type.POSITION, 0);
+                                    BlockFace relative = data == 0 ? BlockFace.BOTTOM : BlockFace.TOP;
+                                    wrapper.set(Type.POSITION, 0, pos.getRelative(relative)); // Y Offset
+                                    wrapper.set(Type.INT, 1, 4); // Self
+                                    break;
+                                case 2: // North
+                                    wrapper.set(Type.INT, 1, 1); // North
+                                    break;
+                                case 3: // South
+                                    wrapper.set(Type.INT, 1, 7); // South
+                                    break;
+                                case 4: // West
+                                    wrapper.set(Type.INT, 1, 3); // West
+                                    break;
+                                case 5: // East
+                                    wrapper.set(Type.INT, 1, 5); // East
+                                    break;
                             }
                         }
                     }

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_13to1_13_1/packets/WorldPackets1_13_1.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_13to1_13_1/packets/WorldPackets1_13_1.java
@@ -17,6 +17,8 @@
  */
 package com.viaversion.viabackwards.protocol.protocol1_13to1_13_1.packets;
 
+import com.viaversion.viaversion.api.minecraft.BlockFace;
+import com.viaversion.viaversion.api.minecraft.Position;
 import com.viaversion.viaversion.api.minecraft.chunks.Chunk;
 import com.viaversion.viaversion.api.minecraft.chunks.ChunkSection;
 import com.viaversion.viaversion.api.protocol.Protocol;
@@ -58,6 +60,45 @@ public class WorldPackets1_13_1 {
         blockRewriter.registerBlockAction(ClientboundPackets1_13.BLOCK_ACTION);
         blockRewriter.registerBlockChange(ClientboundPackets1_13.BLOCK_CHANGE);
         blockRewriter.registerMultiBlockChange(ClientboundPackets1_13.MULTI_BLOCK_CHANGE);
-        blockRewriter.registerEffect(ClientboundPackets1_13.EFFECT, 1010, 2001);
+        protocol.registerClientbound(ClientboundPackets1_13.EFFECT, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.INT); // Effect Id
+                map(Type.POSITION); // Location
+                map(Type.INT); // Data
+                handler(wrapper -> {
+                    int id = wrapper.get(Type.INT, 0);
+                    int data = wrapper.get(Type.INT, 1);
+                    if (id == 1010) { // Play record
+                        wrapper.set(Type.INT, 1, protocol.getMappingData().getNewItemId(data));
+                    } else if (id == 2001) { // Block break + block break sound
+                        wrapper.set(Type.INT, 1, protocol.getMappingData().getNewBlockStateId(data));
+                    } else if (id == 2000) { // Smoke
+                        switch (data) {
+                            case 0: // Down
+                            case 1: // Up
+                                Position pos = wrapper.get(Type.POSITION, 0);
+                                BlockFace relative = data == 0 ? BlockFace.BOTTOM : BlockFace.TOP;
+                                wrapper.set(Type.POSITION, 0, pos.getRelative(relative)); // Y Offset
+                                wrapper.set(Type.INT, 1, 4); // Self
+                                break;
+                            case 2: // North
+                                wrapper.set(Type.INT, 1, 1); // North
+                                break;
+                            case 3: // South
+                                wrapper.set(Type.INT, 1, 7); // South
+                                break;
+                            case 4: // West
+                                wrapper.set(Type.INT, 1, 3); // West
+                                break;
+                            case 5: // East
+                                wrapper.set(Type.INT, 1, 5); // East
+                                break;
+                        }
+                    }
+                });
+            }
+        });
+
     }
 }


### PR DESCRIPTION
This is essentially the analogous of ViaVersion/ViaVersion#2745.

The new `North`, `South`, `East` and `West` are mapped to the same old directions.
The new `Up` and `Down` are mapped to old `Self`, but with a Y offset (of either +1 or -1) to better match the new effect. It ended up looking pretty similar.