### PR TITLE
Add missing block entity NBT on 1.18

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_17_1to1_18/packets/BlockItemPackets1_18.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_17_1to1_18/packets/BlockItemPackets1_18.java
@@ -153,7 +153,7 @@ public final class BlockItemPackets1_18 extends ItemRewriter<Protocol1_17_1To1_1
                     final Position pos = wrapper.get(Type.POSITION1_14, 0);
 
                     // The protocol converters downstream rely on this field, let's add it back
-                    newTag.put("id", new StringTag(identifier));
+                    newTag.put("id", new StringTag("minecraft:" + identifier));
 
                     // Weird glitches happen with the 1.17 client and below if these fields are missing
                     // Some examples are block entity models becoming invisible (e.g.: signs, banners)
@@ -217,7 +217,7 @@ public final class BlockItemPackets1_18 extends ItemRewriter<Protocol1_17_1To1_1
                         tag.put("x", new IntTag((oldChunk.getX() << 4) + blockEntity.sectionX()));
                         tag.put("y", new IntTag(blockEntity.y()));
                         tag.put("z", new IntTag((oldChunk.getZ() << 4) + blockEntity.sectionZ()));
-                        tag.put("id", new StringTag(id));
+                        tag.put("id", new StringTag("minecraft:" + id));
                     }
 
                     final Chunk chunk = new BaseChunk(oldChunk.getX(), oldChunk.getZ(), true, false, mask,


### PR DESCRIPTION
In 1.18, the server no longer sends the `id`, `x`, `y` and `z` fields with block entity NBT. This PR manually adds them during 1.18 -> 1.17.1 conversion.

Clients below 1.18 behave weirdly when the `x`, `y`, `z` values are missing, such as by not rendering the block entity correctly (e.g.: banners on 1.17.1, signs on 1.13, both on 1.9.4):
![BlockEntityNBT-2](https://user-images.githubusercontent.com/6293922/144689104-b2c5556f-3055-49b9-aba3-9e221f8ae7d3.png)

The `id` field is used for conversion between protocols, where it fails silently if it's not present ([most of the times](https://github.com/ViaVersion/ViaVersion/issues/2751)). This results in situations like this:
![BlockEntityNBT](https://user-images.githubusercontent.com/6293922/144688711-961bd818-a1e4-4a95-9a2f-51f8bd0a3dd1.png)