### PR TITLE
Prevent 1.16 -> 1.17 cursor desync with dragging (mostly fixes #389)

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/Protocol1_16_4To1_17.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/Protocol1_16_4To1_17.java
@@ -25,6 +25,7 @@ import com.viaversion.viabackwards.api.rewriters.TranslatableRewriter;
 import com.viaversion.viabackwards.protocol.protocol1_16_4to1_17.packets.BlockItemPackets1_17;
 import com.viaversion.viabackwards.protocol.protocol1_16_4to1_17.packets.EntityPackets1_17;
 import com.viaversion.viabackwards.protocol.protocol1_16_4to1_17.storage.PingRequests;
+import com.viaversion.viabackwards.protocol.protocol1_16_4to1_17.storage.PlayerLastCursorItem;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.minecraft.RegistryType;
 import com.viaversion.viaversion.api.minecraft.TagData;
@@ -249,6 +250,7 @@ public final class Protocol1_16_4To1_17 extends BackwardsProtocol<ClientboundPac
     public void init(UserConnection user) {
         addEntityTracker(user, new EntityTrackerBase(user, Entity1_17Types.PLAYER));
         user.put(new PingRequests());
+        user.put(new PlayerLastCursorItem());
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/packets/BlockItemPackets1_17.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/packets/BlockItemPackets1_17.java
@@ -108,13 +108,14 @@ public final class BlockItemPackets1_17 extends ItemRewriter<Protocol1_16_4To1_1
                     if (mode == 0 && button == 0 && clicked != null) {
                         // Left click PICKUP
                         // Carried item will (usually) be the entire clicked stack
-                        state.setLastCursorItem(clicked.copy());
+                        state.setLastCursorItem(clicked);
                     } else if (mode == 0 && button == 1 && clicked != null) {
+                        boolean halfPickup = state.getLastCursorItem() == null;
                         // Right click PICKUP
                         // Carried item will (usually) be half of the clicked stack (rounding up)
                         // if the clicked slot is empty, otherwise it will (usually) be the whole clicked stack
-                        state.setLastCursorItem(clicked.copy());
-                        if (state.getLastCursorItem() == null) {
+                        state.setLastCursorItem(clicked);
+                        if (halfPickup) {
                             state.getLastCursorItem().setAmount((clicked.amount() + 1) / 2);
                         }
                     } else if (mode == 5 && slot == -999 && (button == 0 || button == 4)) {
@@ -147,6 +148,8 @@ public final class BlockItemPackets1_17 extends ItemRewriter<Protocol1_16_4To1_1
                     short slot = wrapper.passthrough(Type.SHORT);
 
                     Item carried = wrapper.read(Type.FLAT_VAR_INT_ITEM);
+                    wrapper.write(Type.FLAT_VAR_INT_ITEM, handleItemToClient(carried));
+
                     if (carried != null && windowId == -1 && slot == -1) {
                         // This is related to the hack to fix click and drag ghost items above.
                         // After a completed drag, we have no idea how many items remain on the cursor,
@@ -155,9 +158,8 @@ public final class BlockItemPackets1_17 extends ItemRewriter<Protocol1_16_4To1_1
                         // carried item, and the server will helpfully send this packet allowing us
                         // to update the internal state. This is necessary for fixing multiple sequential
                         // click drag actions without intermittent pickup actions.
-                        wrapper.user().get(PlayerLastCursorItem.class).setLastCursorItem(handleItemToServer(carried.copy()));
+                        wrapper.user().get(PlayerLastCursorItem.class).setLastCursorItem(carried);
                     }
-                    wrapper.write(Type.FLAT_VAR_INT_ITEM, handleItemToClient(carried));
                 });
             }
         });

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/packets/BlockItemPackets1_17.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/packets/BlockItemPackets1_17.java
@@ -23,10 +23,12 @@ import com.viaversion.viabackwards.api.rewriters.MapColorRewriter;
 import com.viaversion.viabackwards.protocol.protocol1_16_4to1_17.Protocol1_16_4To1_17;
 import com.viaversion.viabackwards.protocol.protocol1_16_4to1_17.data.MapColorRewrites;
 import com.viaversion.viabackwards.protocol.protocol1_16_4to1_17.storage.PingRequests;
+import com.viaversion.viabackwards.protocol.protocol1_16_4to1_17.storage.PlayerLastCursorItem;
 import com.viaversion.viaversion.api.data.entity.EntityTracker;
 import com.viaversion.viaversion.api.minecraft.BlockChangeRecord;
 import com.viaversion.viaversion.api.minecraft.chunks.Chunk;
 import com.viaversion.viaversion.api.minecraft.chunks.ChunkSection;
+import com.viaversion.viaversion.api.minecraft.item.Item;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.remapper.PacketRemapper;
 import com.viaversion.viaversion.api.type.Type;
@@ -64,7 +66,6 @@ public final class BlockItemPackets1_17 extends ItemRewriter<Protocol1_16_4To1_1
 
         registerSetCooldown(ClientboundPackets1_17.COOLDOWN);
         registerWindowItems(ClientboundPackets1_17.WINDOW_ITEMS, Type.FLAT_VAR_INT_ITEM_ARRAY);
-        registerSetSlot(ClientboundPackets1_17.SET_SLOT, Type.FLAT_VAR_INT_ITEM);
         registerEntityEquipmentArray(ClientboundPackets1_17.ENTITY_EQUIPMENT, Type.FLAT_VAR_INT_ITEM);
         registerTradeList(ClientboundPackets1_17.TRADE_LIST, Type.FLAT_VAR_INT_ITEM);
         registerAdvancements(ClientboundPackets1_17.ADVANCEMENTS, Type.FLAT_VAR_INT_ITEM);
@@ -82,24 +83,85 @@ public final class BlockItemPackets1_17 extends ItemRewriter<Protocol1_16_4To1_1
             }
         });
 
-        //TODO This will cause desync issues for players under certain circumstances, but mostly works:tm:
+        // TODO Since the carried and modified items are typically set incorrectly, the server sends unnecessary
+        // set slot packets after practically every window click, since it thinks the client and server
+        // inventories are desynchronized. Ideally, we want to store a replica of each container state, and update
+        // it appropriately for both serverbound and clientbound window packets, then fill in the carried
+        // and modified items array as appropriate here. That would be a ton of work and replicated vanilla code,
+        // and the hack below mitigates the worst side effects of this issue, which is an incorrect carried item
+        // sent to the client when a right/left click drag is started. It works, at least for now...
         protocol.registerServerbound(ServerboundPackets1_16_2.CLICK_WINDOW, new PacketRemapper() {
             @Override
             public void registerMap() {
-                map(Type.UNSIGNED_BYTE); // Window Id
-                map(Type.SHORT); // Slot
-                map(Type.BYTE); // Button
-                map(Type.SHORT, Type.NOTHING); // Action id - removed
-                map(Type.VAR_INT); // Mode
+                map(Type.UNSIGNED_BYTE);
                 handler(wrapper -> {
+                    short slot = wrapper.passthrough(Type.SHORT); // Slot
+                    byte button = wrapper.passthrough(Type.BYTE); // Button
+                    wrapper.read(Type.SHORT); // Action id - removed
+                    int mode = wrapper.passthrough(Type.VAR_INT); // Mode
+                    Item clicked = handleItemToServer(wrapper.read(Type.FLAT_VAR_INT_ITEM)); // Clicked item
+
                     // The 1.17 client would check the entire inventory for changes before -> after a click and send the changed slots here
                     wrapper.write(Type.VAR_INT, 0); // Empty array of slot+item
 
-                    // Expected is the carried item after clicking, old clients send the clicked one (*mostly* being the same)
-                    handleItemToServer(wrapper.passthrough(Type.FLAT_VAR_INT_ITEM));
+                    PlayerLastCursorItem state = wrapper.user().get(PlayerLastCursorItem.class);
+                    if (mode == 0 && button == 0 && clicked != null) {
+                        // Left click PICKUP
+                        // Carried item will (usually) be the entire clicked stack
+                        state.setLastCursorItem(clicked.copy());
+                    } else if (mode == 0 && button == 1 && clicked != null) {
+                        // Right click PICKUP
+                        // Carried item will (usually) be half of the clicked stack (rounding up)
+                        // if the clicked slot is empty, otherwise it will (usually) be the whole clicked stack
+                        state.setLastCursorItem(clicked.copy());
+                        if (state.getLastCursorItem() == null) {
+                            state.getLastCursorItem().setAmount((clicked.amount() + 1) / 2);
+                        }
+                    } else if (mode == 5 && slot == -999 && (button == 0 || button == 4)) {
+                        // Start drag (left or right click)
+                        // Preserve guessed carried item and forward to server
+                        // This mostly fixes the click and drag ghost item issue
+
+                        // no-op
+                    } else {
+                        // Carried item unknown (TODO)
+                        state.setLastCursorItem(null);
+                    }
+
+                    Item carried = state.getLastCursorItem();
+                    if (carried == null) {
+                        // Expected is the carried item after clicking, old clients send the clicked one (*mostly* being the same)
+                        wrapper.write(Type.FLAT_VAR_INT_ITEM, clicked);
+                    } else {
+                        wrapper.write(Type.FLAT_VAR_INT_ITEM, carried);
+                    }
                 });
             }
         });
+
+        protocol.registerClientbound(ClientboundPackets1_17.SET_SLOT, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                handler(wrapper -> {
+                    short windowId = wrapper.passthrough(Type.UNSIGNED_BYTE);
+                    short slot = wrapper.passthrough(Type.SHORT);
+
+                    Item carried = wrapper.read(Type.FLAT_VAR_INT_ITEM);
+                    if (carried != null && windowId == -1 && slot == -1) {
+                        // This is related to the hack to fix click and drag ghost items above.
+                        // After a completed drag, we have no idea how many items remain on the cursor,
+                        // and vanilla logic replication would be required to calculate the value.
+                        // When the click drag complete packet is sent, we will send an incorrect
+                        // carried item, and the server will helpfully send this packet allowing us
+                        // to update the internal state. This is necessary for fixing multiple sequential
+                        // click drag actions without intermittent pickup actions.
+                        wrapper.user().get(PlayerLastCursorItem.class).setLastCursorItem(handleItemToServer(carried.copy()));
+                    }
+                    wrapper.write(Type.FLAT_VAR_INT_ITEM, handleItemToClient(carried));
+                });
+            }
+        });
+
         protocol.registerServerbound(ServerboundPackets1_16_2.WINDOW_CONFIRMATION, null, new PacketRemapper() {
             @Override
             public void registerMap() {

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/packets/BlockItemPackets1_17.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/packets/BlockItemPackets1_17.java
@@ -110,13 +110,13 @@ public final class BlockItemPackets1_17 extends ItemRewriter<Protocol1_16_4To1_1
                         // Carried item will (usually) be the entire clicked stack
                         state.setLastCursorItem(clicked);
                     } else if (mode == 0 && button == 1 && clicked != null) {
-                        boolean halfPickup = state.getLastCursorItem() == null;
                         // Right click PICKUP
                         // Carried item will (usually) be half of the clicked stack (rounding up)
                         // if the clicked slot is empty, otherwise it will (usually) be the whole clicked stack
-                        state.setLastCursorItem(clicked);
-                        if (halfPickup) {
-                            state.getLastCursorItem().setAmount((clicked.amount() + 1) / 2);
+                        if (state.isSet()) {
+                            state.setLastCursorItem(clicked);
+                        } else {
+                            state.setLastCursorItem(clicked, (clicked.amount() + 1) / 2);
                         }
                     } else if (mode == 5 && slot == -999 && (button == 0 || button == 4)) {
                         // Start drag (left or right click)

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/packets/BlockItemPackets1_17.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/packets/BlockItemPackets1_17.java
@@ -148,8 +148,6 @@ public final class BlockItemPackets1_17 extends ItemRewriter<Protocol1_16_4To1_1
                     short slot = wrapper.passthrough(Type.SHORT);
 
                     Item carried = wrapper.read(Type.FLAT_VAR_INT_ITEM);
-                    wrapper.write(Type.FLAT_VAR_INT_ITEM, handleItemToClient(carried));
-
                     if (carried != null && windowId == -1 && slot == -1) {
                         // This is related to the hack to fix click and drag ghost items above.
                         // After a completed drag, we have no idea how many items remain on the cursor,
@@ -160,6 +158,8 @@ public final class BlockItemPackets1_17 extends ItemRewriter<Protocol1_16_4To1_1
                         // click drag actions without intermittent pickup actions.
                         wrapper.user().get(PlayerLastCursorItem.class).setLastCursorItem(carried);
                     }
+
+                    wrapper.write(Type.FLAT_VAR_INT_ITEM, handleItemToClient(carried));
                 });
             }
         });

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/storage/PlayerLastCursorItem.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/storage/PlayerLastCursorItem.java
@@ -25,16 +25,28 @@ public class PlayerLastCursorItem implements StorableObject {
     private Item lastCursorItem;
 
     public Item getLastCursorItem() {
-        return lastCursorItem;
+        return copyItem(lastCursorItem);
     }
 
     public void setLastCursorItem(Item item) {
+        this.lastCursorItem = copyItem(item);
+    }
+
+    public void setLastCursorItem(Item item, int amount) {
+        this.lastCursorItem = copyItem(item);
+        this.lastCursorItem.setAmount(amount);
+    }
+
+    public boolean isSet() {
+        return lastCursorItem != null;
+    }
+
+    private static Item copyItem(Item item) {
         if (item == null) {
-            this.lastCursorItem = null;
-            return;
+            return null;
         }
         Item copy = new DataItem(item);
         copy.setTag(copy.tag() == null ? null : copy.tag().clone());
-        this.lastCursorItem = copy;
+        return copy;
     }
 }

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/storage/PlayerLastCursorItem.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/storage/PlayerLastCursorItem.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of ViaBackwards - https://github.com/ViaVersion/ViaBackwards
+ * Copyright (C) 2016-2022 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viabackwards.protocol.protocol1_16_4to1_17.storage;
+
+import com.viaversion.viaversion.api.connection.StorableObject;
+import com.viaversion.viaversion.api.minecraft.item.Item;
+
+public class PlayerLastCursorItem implements StorableObject {
+    private Item lastCursorItem;
+
+    public Item getLastCursorItem() {
+        return lastCursorItem;
+    }
+
+    public void setLastCursorItem(Item item) {
+        this.lastCursorItem = item;
+    }
+}

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/storage/PlayerLastCursorItem.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/storage/PlayerLastCursorItem.java
@@ -18,6 +18,7 @@
 package com.viaversion.viabackwards.protocol.protocol1_16_4to1_17.storage;
 
 import com.viaversion.viaversion.api.connection.StorableObject;
+import com.viaversion.viaversion.api.minecraft.item.DataItem;
 import com.viaversion.viaversion.api.minecraft.item.Item;
 
 public class PlayerLastCursorItem implements StorableObject {
@@ -28,6 +29,12 @@ public class PlayerLastCursorItem implements StorableObject {
     }
 
     public void setLastCursorItem(Item item) {
-        this.lastCursorItem = item;
+        if (item == null) {
+            this.lastCursorItem = null;
+            return;
+        }
+        Item copy = new DataItem(item);
+        copy.setTag(copy.tag() == null ? null : copy.tag().clone());
+        this.lastCursorItem = copy;
     }
 }

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_17to1_17_1/Protocol1_17To1_17_1.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_17to1_17_1/Protocol1_17To1_17_1.java
@@ -18,6 +18,7 @@
 package com.viaversion.viabackwards.protocol.protocol1_17to1_17_1;
 
 import com.viaversion.viabackwards.api.BackwardsProtocol;
+import com.viaversion.viabackwards.protocol.protocol1_16_4to1_17.storage.PlayerLastCursorItem;
 import com.viaversion.viabackwards.protocol.protocol1_17to1_17_1.storage.InventoryStateIds;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.minecraft.item.Item;
@@ -91,7 +92,14 @@ public final class Protocol1_17To1_17_1 extends BackwardsProtocol<ClientboundPac
                     wrapper.write(Type.FLAT_VAR_INT_ITEM_ARRAY, wrapper.read(Type.FLAT_VAR_INT_ITEM_ARRAY_VAR_INT));
 
                     // Carried item - should work without adding it to the array above
-                    wrapper.read(Type.FLAT_VAR_INT_ITEM);
+                    Item carried = wrapper.read(Type.FLAT_VAR_INT_ITEM);
+                    if (carried != null) {
+                        // For click drag ghost item fix -- since the state ID is always wrong,
+                        // the server always resends the entire window contents after a drag action,
+                        // which is useful since we need to update the carried item in preparation
+                        // for a subsequent drag
+                        wrapper.user().get(PlayerLastCursorItem.class).setLastCursorItem(carried.copy());
+                    }
                 });
             }
         });

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_17to1_17_1/Protocol1_17To1_17_1.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_17to1_17_1/Protocol1_17To1_17_1.java
@@ -98,7 +98,7 @@ public final class Protocol1_17To1_17_1 extends BackwardsProtocol<ClientboundPac
                         // the server always resends the entire window contents after a drag action,
                         // which is useful since we need to update the carried item in preparation
                         // for a subsequent drag
-                        wrapper.user().get(PlayerLastCursorItem.class).setLastCursorItem(carried.copy());
+                        wrapper.user().get(PlayerLastCursorItem.class).setLastCursorItem(carried);
                     }
                 });
             }

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_17to1_17_1/Protocol1_17To1_17_1.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_17to1_17_1/Protocol1_17To1_17_1.java
@@ -93,12 +93,15 @@ public final class Protocol1_17To1_17_1 extends BackwardsProtocol<ClientboundPac
 
                     // Carried item - should work without adding it to the array above
                     Item carried = wrapper.read(Type.FLAT_VAR_INT_ITEM);
-                    if (carried != null) {
+
+                    PlayerLastCursorItem lastCursorItem = wrapper.user().get(PlayerLastCursorItem.class);
+                    if (lastCursorItem != null) {
                         // For click drag ghost item fix -- since the state ID is always wrong,
                         // the server always resends the entire window contents after a drag action,
                         // which is useful since we need to update the carried item in preparation
                         // for a subsequent drag
-                        wrapper.user().get(PlayerLastCursorItem.class).setLastCursorItem(carried);
+
+                        lastCursorItem.setLastCursorItem(carried);
                     }
                 });
             }


### PR DESCRIPTION
1.17 clients must report modified slots and the carried item when clicking a window, and the server will respond by sending set slot packets where it disagrees with the client about the window state. It's fine to send an empty modified items array for legacy clients, although we miss out on the error checking benefit, however, failing to send the correct carried item is problematic.

When a legacy client sends the start drag packet with an incorrect carried item (and since the current behavior is to send the clicked item as the carried item and typically drag actions occur on empty slots, this is almost always the case), the server will detect the desynchronization of the carried item and immediately resend the correct carried item before the drag action has occurred. Due to some completely bizarre behavior of legacy clients, the client receives the correct amount right after it starts dragging but does not apply it to the item stack being dragged until *after* the drag action completes. This is problematic because the drag action itself affects the count of the carried item, so resetting it to the pre-drag count causes ghost carried items.

My solution is to send an educated guess about what the actual carried item probably is, rather than the clicked slot, when the start drag packet is sent. Hopefully, the server accepts this guess and does not attempt to resend the carried item, which is what causes the issue. The guess is made by saving the last left-clicked stack, the last right-clicked stack if the previous cursor was not empty, or half of the last right-clicked stack if the previous cursor was empty. This only partially replicates vanilla behavior, but it's good enough to mitigate this issue in most cases. Additionally, we listen for each time the server tells us the actual state of the carried item and update our guess accordingly. This second method uses takes advantage fact that Via sends incorrect state IDs for each set slot action during an ongoing drag, as well as the stop drag packet. Via will only send any given state ID for a single click packet, but the vanilla client will send the same state ID for each packet in the drag action series. The server is unhappy about this and resends the entire window contents for each modified slot in a drag action and one additional time for the completed drag. If this bug is ever fixed, it will cause my patch here to stop working correctly, since, without the extra information about the carried item gained from these window resends, we would not be able to determine the amount of an item left immediately after a drag action. Since one drag action can immediately follow another, the carried count must be appropriately updated after each drag. While helpful here, this issue has the unfortunate side effect of consuming quite a bit of unnecessary bandwidth.

This is an extremely janky fix that does not cover all edge cases. Specifically, the logic that detects the current carried item is limited and incomplete. Although the results are passable right now, I fear that eventually, as the server becomes more strict or finds additional uses for the reported carried and modified items, simple fixes like these will not be enough. Ultimately, Via may need to store a replica of every container state and update it appropriately when either the client or server makes modifications. That would enable us to use the actual container state to fill in the gaps left by legacy clients. This would be a future-proof solution, however, the implementation effort is high and would involve replicating all of the vanilla inventory click logic.