### PR TITLE
Fix 1.7 window confirmation exception

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/packets/BlockItemPackets1_17.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/packets/BlockItemPackets1_17.java
@@ -174,7 +174,7 @@ public final class BlockItemPackets1_17 extends ItemRewriter<Protocol1_16_4To1_1
                     }
 
                     // Handle ping packet replacement
-                    short inventoryId = wrapper.read(Type.UNSIGNED_BYTE);
+                    short inventoryId = wrapper.read(Type.BYTE);
                     short confirmationId = wrapper.read(Type.SHORT);
                     boolean accepted = wrapper.read(Type.BOOLEAN);
                     if (inventoryId == 0 && accepted && wrapper.user().get(PingRequests.class).removeId(confirmationId)) {


### PR DESCRIPTION
[19:42:08 INFO]: DefineOutside joined the game
[19:42:08 INFO]: DefineOutside[/127.0.0.1:51317] logged in with entity id 489 at ([world]203.49666077218595, 65.0, 140.4802544136537)
[19:42:08 WARN]: [ViaVersion] ERROR IN Protocol1_16_4To1_17 IN REMAP OF WINDOW_CONFIRMATION (0x07)
[19:42:08 WARN]: io.netty.handler.codec.DecoderException: com.viaversion.viaversion.exception.InformativeException: Please post this error to https://github.com/ViaVersion/ViaVersion/issues and follow the issue template
[19:42:08 WARN]: {Packet Type: null, Type: Unsigned Byte, Data: [], Source 0: com.viaversion.viabackwards.protocol.protocol1_16_4to1_17.packets.BlockItemPackets1_17$4 (Anonymous), Packet ID: -1}
[19:42:08 WARN]: Actual Error:
[19:42:08 WARN]: at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:477)
[19:42:08 WARN]: at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:276)
[19:42:08 WARN]: at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
[19:42:08 WARN]: at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
[19:42:08 WARN]: at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
[19:42:08 WARN]: at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324)
[19:42:08 WARN]: at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
[19:42:08 WARN]: at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
[19:42:08 WARN]: at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
[19:42:08 WARN]: at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
[19:42:08 WARN]: at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
[19:42:08 WARN]: at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
[19:42:08 WARN]: at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
[19:42:08 WARN]: at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
[19:42:08 WARN]: at io.netty.handler.flush.FlushConsolidationHandler.channelRead(FlushConsolidationHandler.java:152)
[19:42:08 WARN]: at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
[19:42:08 WARN]: at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
[19:42:08 WARN]: at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
[19:42:08 WARN]: at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
[19:42:08 WARN]: at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
[19:42:08 WARN]: at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
[19:42:08 WARN]: at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
[19:42:08 WARN]: at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
[19:42:08 WARN]: at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:719)
[19:42:08 WARN]: at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:655)
[19:42:08 WARN]: at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:581)
[19:42:08 WARN]: at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:493)
[19:42:08 WARN]: at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
[19:42:08 WARN]: at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
[19:42:08 WARN]: at java.base/java.lang.Thread.run(Thread.java:833)
[19:42:08 WARN]: Caused by: com.viaversion.viaversion.exception.InformativeException: Please post this error to https://github.com/ViaVersion/ViaVersion/issues and follow the issue template

This fixes this exception with window confirmations.  Tested on Paper 1.19.