### PR TITLE
Fix Player Block Placement Translation in 1.10 -> 1.11

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_10to1_11/packets/PlayerPackets1_11.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_10to1_11/packets/PlayerPackets1_11.java
@@ -34,7 +34,7 @@ public class PlayerPackets1_11 {
     private static final ValueTransformer<Short, Float> TO_NEW_FLOAT = new ValueTransformer<Short, Float>(Type.FLOAT) {
         @Override
         public Float transform(PacketWrapper wrapper, Short inputValue) throws Exception {
-            return inputValue / 15f;
+            return inputValue / 16f;
         }
     };
 


### PR DESCRIPTION
This pull request fixes the conversion of the facing coordinates, in <1.11 Minecraft calculates the facing * 16 when sending, in >=1.11 this is removed, in ViaVersion this is also correctly remapped but in ViaBackwards not 16 but 15 was used as conversion number. 

ViaVersion (1.11 -> 1.10)
![image](https://user-images.githubusercontent.com/60033407/184511196-bcb6f9c7-7183-4a4a-bf46-e4a378934034.png)
