### PR TITLE
Fix 1.18.2->1.19 CHAT_MESSAGE using static timestamp

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_18_2to1_19/Protocol1_18_2To1_19.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_18_2to1_19/Protocol1_18_2To1_19.java
@@ -234,7 +234,7 @@ public final class Protocol1_18_2To1_19 extends BackwardsProtocol<ClientboundPac
             @Override
             public void registerMap() {
                 map(Type.STRING); // Message
-                create(Type.LONG, Instant.now().toEpochMilli()); // Timestamp
+                handler(wrapper -> wrapper.write(Type.LONG, Instant.now().toEpochMilli())); // Timestamp
                 create(Type.LONG, 0L); // Salt
                 handler(wrapper -> {
                     final String message = wrapper.get(Type.STRING, 0);


### PR DESCRIPTION
Fix MC 1.18.2 -> MC 1.19 CHAT_MESSAGE packet conversion using a static timestamp. Fixes `<PLAYER> sent expired chat: '<MESSAGE>'` console warning on every converted chat message 5 minutes after proxy start.