### PR TITLE
Fix 1.12.2 and older clients crash near to 1.19 horn

### DIFF
--- a/common/src/main/resources/assets/viabackwards/data/mapping-1.18to1.19.json
+++ b/common/src/main/resources/assets/viabackwards/data/mapping-1.18to1.19.json
@@ -703,7 +703,7 @@
       "name": "1.19 Disc Fragment"
     },
     "minecraft:goat_horn": {
-      "id": "minecraft:dead_horn_coral",
+      "id": "minecraft:dead_horn_coral_fan",
       "name": "1.19 Goat Horn"
     }
   },


### PR DESCRIPTION
This is just a workaround, as the problem is in the 1.12->1.13 mapping, where the following dead corals are missing:

minecraft:dead_tube_coral
minecraft:dead_brain_coral
minecraft:dead_bubble_coral
minecraft:dead_fire_coral
minecraft:dead_horn_coral

I tried to fix it at https://github.com/LoboMetalurgico/ViaBackwards/blob/fix/1.13-coral/common/src/main/resources/assets/viabackwards/data/mapping-1.12to1.13.json#L4805-L4809 | https://github.com/LoboMetalurgico/ViaBackwards/blob/fix/1.13-coral/common/src/main/resources/assets/viabackwards/data/mapping-1.12to1.13.json#L5745-L5764 | , but I was not successful (on console I receive "No old entry for minecraft:dead_bush :(" 5 times).

However, this workaround has been tested and is working.