### PR TITLE
Fix enchantments in 1.12 -> 1.13

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_12_2to1_13/packets/BlockItemPackets1_13.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_12_2to1_13/packets/BlockItemPackets1_13.java
@@ -56,6 +56,7 @@ import com.viaversion.viaversion.protocols.protocol1_13to1_12_2.data.SpawnEggRew
 import com.viaversion.viaversion.protocols.protocol1_13to1_12_2.types.Chunk1_13Type;
 import com.viaversion.viaversion.protocols.protocol1_9_1_2to1_9_3_4.types.Chunk1_9_3_4Type;
 import com.viaversion.viaversion.protocols.protocol1_9_3to1_9_1_2.storage.ClientWorld;
+import com.viaversion.viaversion.util.Key;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -634,7 +635,7 @@ public class BlockItemPackets1_13 extends com.viaversion.viabackwards.api.rewrit
                 lore.add(new StringTag(mappedEnchantmentId + " " + EnchantmentRewriter.getRomanNumber(level)));
                 noMapped.add(enchantmentEntry);
             } else if (!newId.isEmpty()) {
-                Short oldId = Protocol1_13To1_12_2.MAPPINGS.getOldEnchantmentsIds().inverse().get(newId);
+                Short oldId = Protocol1_13To1_12_2.MAPPINGS.getOldEnchantmentsIds().inverse().get(Key.stripMinecraftNamespace(newId));
                 if (oldId == null) {
                     if (!newId.startsWith("viaversion:legacy/")) {
                         // Custom enchant (?)


### PR DESCRIPTION
Tested on 1.13.2 and 1.19.3 server.

Before:
https://user-images.githubusercontent.com/17585784/225102384-6c0f32d2-37dd-4d72-ac48-2d9ac6790e47.mp4

After:
https://user-images.githubusercontent.com/17585784/225102437-3fd835fa-8b6b-4214-ada1-32cf1dfaf787.mp4


Tested item:
```
/give @s diamond_shovel{Enchantments:[{id:"minecraft:efficiency",lvl:5}]}
```