### PR TITLE
Fixed max player count value mapping

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_1to1_16_2/packets/EntityPackets1_16_2.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_1to1_16_2/packets/EntityPackets1_16_2.java
@@ -100,7 +100,7 @@ public class EntityPackets1_16_2 extends EntityRewriter<ClientboundPackets1_16_2
                 map(Type.LONG); // Seed
                 handler(wrapper -> {
                     int maxPlayers = wrapper.read(Type.VAR_INT);
-                    wrapper.write(Type.UNSIGNED_BYTE, (short) Math.max(maxPlayers, 255));
+                    wrapper.write(Type.UNSIGNED_BYTE, (short) Math.min(maxPlayers, 255));
                 });
                 // ...
                 handler(getTrackerHandler(Entity1_16_2Types.PLAYER, Type.INT));


### PR DESCRIPTION
Fixes 1.7 clients always having a player list with size 255 no matter the max player count of the server