### PR TITLE
Translate hoverEvents on books

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_15_2to1_16/packets/BlockItemPackets1_16.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_15_2to1_16/packets/BlockItemPackets1_16.java
@@ -370,16 +370,20 @@ public class BlockItemPackets1_16 extends com.viaversion.viabackwards.api.rewrit
         // fix hover events on pages by changing "contents" to "value"
         for(Tag page : pagesTag){
             StringTag stringPage = (StringTag) page;
-            JsonObject jsonObject = JsonParser.parseString(stringPage.getValue()).getAsJsonObject();
-            List<JsonObject> hoverEvents = new ArrayList<>();
-            searchForKeys(jsonObject, "hoverEvent", hoverEvents);
-            for(JsonObject object : hoverEvents){
-                if(object.has("contents")){
-                    object.add("value", object.remove("contents"));
+            try{
+                JsonObject jsonObject = JsonParser.parseString(stringPage.getValue()).getAsJsonObject();
+                List<JsonObject> hoverEvents = new ArrayList<>();
+                searchForKeys(jsonObject, "hoverEvent", hoverEvents);
+                for(JsonObject object : hoverEvents){
+                    if(object.has("contents")){
+                        object.add("value", object.remove("contents"));
+                    }
                 }
-            }
-            if(!hoverEvents.isEmpty()){
-                stringPage.setValue(jsonObject.toString());
+                if(!hoverEvents.isEmpty()){
+                    stringPage.setValue(jsonObject.toString());
+                }
+            } catch (final Exception e){
+                // Invalid json object
             }
         }
     }


### PR DESCRIPTION
From 1.16, the hoverEvent content is located in `contents` or `value`,  older versions only accept ` value`. This was not handled by ViaBackwards. See issue #572