### PR TITLE
Removed outdated chat-types setting from config.yml

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/ViaBackwardsConfig.java
+++ b/common/src/main/java/com/viaversion/viabackwards/ViaBackwardsConfig.java
@@ -21,10 +21,8 @@ import com.viaversion.viaversion.util.Config;
 import java.io.File;
 import java.net.URL;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class ViaBackwardsConfig extends Config implements com.viaversion.viabackwards.api.ViaBackwardsConfig {
 
@@ -34,7 +32,6 @@ public class ViaBackwardsConfig extends Config implements com.viaversion.viaback
     private boolean alwaysShowOriginalMobName;
     private boolean fix1_13FormattedInventoryTitles;
     private boolean handlePingsAsInvAcknowledgements;
-    private Map<String, String> chatTypeFormats;
 
     public ViaBackwardsConfig(File configFile) {
         super(configFile);
@@ -53,7 +50,6 @@ public class ViaBackwardsConfig extends Config implements com.viaversion.viaback
         fix1_13FormattedInventoryTitles = getBoolean("fix-formatted-inventory-titles", true);
         alwaysShowOriginalMobName = getBoolean("always-show-original-mob-name", true);
         handlePingsAsInvAcknowledgements = getBoolean("handle-pings-as-inv-acknowledgements", false);
-        chatTypeFormats = get("chat-types-1_19_1", Map.class, new HashMap<String, String>());
     }
 
     @Override
@@ -84,11 +80,6 @@ public class ViaBackwardsConfig extends Config implements com.viaversion.viaback
     @Override
     public boolean handlePingsAsInvAcknowledgements() {
         return handlePingsAsInvAcknowledgements || Boolean.getBoolean("com.viaversion.handlePingsAsInvAcknowledgements");
-    }
-
-    @Override
-    public @Nullable String chatTypeFormat(final String translationKey) {
-        return chatTypeFormats.get(translationKey);
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viabackwards/api/ViaBackwardsConfig.java
+++ b/common/src/main/java/com/viaversion/viabackwards/api/ViaBackwardsConfig.java
@@ -17,8 +17,6 @@
  */
 package com.viaversion.viabackwards.api;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
-
 public interface ViaBackwardsConfig {
 
     /**
@@ -52,6 +50,4 @@ public interface ViaBackwardsConfig {
     boolean alwaysShowOriginalMobName();
 
     boolean handlePingsAsInvAcknowledgements();
-
-    @Nullable String chatTypeFormat(String translationKey);
 }

--- a/common/src/main/resources/assets/viabackwards/config.yml
+++ b/common/src/main/resources/assets/viabackwards/config.yml
@@ -20,13 +20,3 @@ fix-formatted-inventory-titles: true
 # Sends inventory acknowledgement packets to act as a replacement for ping packets for sub 1.17 clients.
 # This only takes effect for ids in the short range. Useful for anticheat compatibility.
 handle-pings-as-inv-acknowledgements: false
-#
-# 1.19.1 chat type formats.
-chat-types-1_19_1:
-  "chat.type.text": "<%s> %s"
-  "chat.type.announcement": "[%s] %s"
-  "commands.message.display.incoming": "%s whispers to you: %s"
-  "commands.message.display.outgoing": "You whisper to %s: %s"
-  "chat.type.team.text": "%s <%s> %s"
-  "chat.type.team.sent": "-> %s <%s> %s"
-  "chat.type.emote": "* %s %s"


### PR DESCRIPTION
Yeah, the setting is unused so we don't need it anymore