### PR TITLE
Add an option to disable transaction tracking

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/ViaBackwardsConfig.java
+++ b/common/src/main/java/com/viaversion/viabackwards/ViaBackwardsConfig.java
@@ -32,6 +32,7 @@ public class ViaBackwardsConfig extends Config implements com.viaversion.viaback
     private boolean alwaysShowOriginalMobName;
     private boolean fix1_13FormattedInventoryTitles;
     private boolean handlePingsAsInvAcknowledgements;
+    private boolean transactionTracking;
 
     public ViaBackwardsConfig(File configFile) {
         super(configFile);
@@ -50,6 +51,7 @@ public class ViaBackwardsConfig extends Config implements com.viaversion.viaback
         fix1_13FormattedInventoryTitles = getBoolean("fix-formatted-inventory-titles", true);
         alwaysShowOriginalMobName = getBoolean("always-show-original-mob-name", true);
         handlePingsAsInvAcknowledgements = getBoolean("handle-pings-as-inv-acknowledgements", false);
+        transactionTracking = getBoolean("transaction-tracking", true);
     }
 
     @Override
@@ -80,6 +82,11 @@ public class ViaBackwardsConfig extends Config implements com.viaversion.viaback
     @Override
     public boolean handlePingsAsInvAcknowledgements() {
         return handlePingsAsInvAcknowledgements || Boolean.getBoolean("com.viaversion.handlePingsAsInvAcknowledgements");
+    }
+
+    @Override
+    public boolean transactionTracking() {
+        return transactionTracking;
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viabackwards/api/ViaBackwardsConfig.java
+++ b/common/src/main/java/com/viaversion/viabackwards/api/ViaBackwardsConfig.java
@@ -50,4 +50,12 @@ public interface ViaBackwardsConfig {
     boolean alwaysShowOriginalMobName();
 
     boolean handlePingsAsInvAcknowledgements();
+
+    /**
+     * If pings are handled as inventory acknowledgements, this will enable transaction tracking and skip
+     * duplicate/junk inventory acknowledgements.
+     *
+     * @return true if enabled
+     */
+    boolean transactionTracking();
 }

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/Protocol1_16_4To1_17.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/Protocol1_16_4To1_17.java
@@ -169,7 +169,9 @@ public final class Protocol1_16_4To1_17 extends BackwardsProtocol<ClientboundPac
             int id = wrapper.read(Type.INT);
             short shortId = (short) id;
             if (id == shortId && ViaBackwards.getConfig().handlePingsAsInvAcknowledgements()) {
-                wrapper.user().get(PingRequests.class).addId(shortId);
+                if (ViaBackwards.getConfig().transactionTracking()) {
+                    wrapper.user().get(PingRequests.class).addId(shortId);
+                }
 
                 // Send inventory acknowledgement to replace ping packet functionality in the unsigned byte range
                 PacketWrapper acknowledgementPacket = wrapper.create(ClientboundPackets1_16_2.WINDOW_CONFIRMATION);

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/packets/BlockItemPackets1_17.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/packets/BlockItemPackets1_17.java
@@ -165,7 +165,7 @@ public final class BlockItemPackets1_17 extends ItemRewriter<ClientboundPackets1
             short inventoryId = wrapper.read(Type.UNSIGNED_BYTE);
             short confirmationId = wrapper.read(Type.SHORT);
             boolean accepted = wrapper.read(Type.BOOLEAN);
-            if (inventoryId == 0 && accepted && wrapper.user().get(PingRequests.class).removeId(confirmationId)) {
+            if (inventoryId == 0 && accepted && (!ViaBackwards.getConfig().transactionTracking() || wrapper.user().get(PingRequests.class).removeId(confirmationId))) {
                 PacketWrapper pongPacket = wrapper.create(ServerboundPackets1_17.PONG);
                 pongPacket.write(Type.INT, (int) confirmationId);
                 pongPacket.sendToServer(Protocol1_16_4To1_17.class);

--- a/common/src/main/resources/assets/viabackwards/config.yml
+++ b/common/src/main/resources/assets/viabackwards/config.yml
@@ -20,3 +20,7 @@ fix-formatted-inventory-titles: true
 # Sends inventory acknowledgement packets to act as a replacement for ping packets for sub 1.17 clients.
 # This only takes effect for ids in the short range. Useful for anticheat compatibility.
 handle-pings-as-inv-acknowledgements: false
+#
+# Stores all inventory acknowledgement packets sent to a player and filters the response packets accordingly.
+# Some anticheats may require this to be disabled.
+transaction-tracking: true


### PR DESCRIPTION
By default, ViaBackwards stores all inventory acknowledgement (transaction) IDs sent to a player and checks them when a player responds.

This may lead to anticheat incompatibility if, for some instance, two identical IDs are sent to a player and two responses are expected (in which case, with transaction tracking, only one would pass through ViaBackwards).

This PR proposes to add an option to disable this feature.