### PR TITLE
Fix packet id of player velocity packets

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_20to1_20_2/rewriter/EntityPacketRewriter1_20_2.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_20to1_20_2/rewriter/EntityPacketRewriter1_20_2.java
@@ -90,7 +90,7 @@ public final class EntityPacketRewriter1_20_2 extends EntityRewriter<Clientbound
                     wrapper.send(Protocol1_20To1_20_2.class);
                     wrapper.cancel();
 
-                    final PacketWrapper velocityPacket = wrapper.create(ClientboundPackets1_20_2.ENTITY_VELOCITY);
+                    final PacketWrapper velocityPacket = wrapper.create(ClientboundPackets1_19_4.ENTITY_VELOCITY);
                     velocityPacket.write(Type.VAR_INT, entityId);
                     velocityPacket.write(Type.SHORT, velocityX);
                     velocityPacket.write(Type.SHORT, velocityY);


### PR DESCRIPTION
When a player is moving on a 1.20.2 server and another player in 1.20.1 or older joins (and sees him while joining) he was kicked because the packet was sent als id 86 instead of 84.