### PR TITLE
Fixed ViaBackwards#init start condition not working

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/ViaBackwards.java
+++ b/common/src/main/java/com/viaversion/viabackwards/ViaBackwards.java
@@ -28,7 +28,7 @@ public final class ViaBackwards {
     private static ViaBackwardsConfig config;
 
     public static void init(ViaBackwardsPlatform platform, ViaBackwardsConfig config) {
-        Preconditions.checkArgument(platform != null, "ViaBackwards is already initialized");
+        Preconditions.checkArgument(ViaBackwardsPlatform.platform != null, "ViaBackwards is already initialized");
 
         ViaBackwards.platform = platform;
         ViaBackwards.config = config;


### PR DESCRIPTION
This pull request fixes the check that it checks the global field and not the constructor parameter