### PR TITLE
Allow platform implementation to define config path

### DIFF
--- a/bukkit/src/main/java/com/viaversion/viabackwards/BukkitPlugin.java
+++ b/bukkit/src/main/java/com/viaversion/viabackwards/BukkitPlugin.java
@@ -27,10 +27,12 @@ import com.viaversion.viaversion.api.Via;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.io.File;
+
 public class BukkitPlugin extends JavaPlugin implements ViaBackwardsPlatform {
 
     public BukkitPlugin() {
-        Via.getManager().addEnableListener(() -> init(getDataFolder()));
+        Via.getManager().addEnableListener(() -> init(new File(getDataFolder(), "config.yml")));
     }
 
     @Override

--- a/bungee/src/main/java/com/viaversion/viabackwards/BungeePlugin.java
+++ b/bungee/src/main/java/com/viaversion/viabackwards/BungeePlugin.java
@@ -20,14 +20,15 @@ package com.viaversion.viabackwards;
 
 import com.viaversion.viabackwards.api.ViaBackwardsPlatform;
 import com.viaversion.viaversion.api.Via;
-import com.viaversion.viaversion.api.data.MappingDataLoader;
 import net.md_5.bungee.api.plugin.Plugin;
+
+import java.io.File;
 
 public class BungeePlugin extends Plugin implements ViaBackwardsPlatform {
 
     @Override
     public void onLoad() {
-        Via.getManager().addEnableListener(() -> this.init(getDataFolder()));
+        Via.getManager().addEnableListener(() -> this.init(new File(getDataFolder(), "config.yml")));
     }
 
 

--- a/common/src/main/java/com/viaversion/viabackwards/api/ViaBackwardsPlatform.java
+++ b/common/src/main/java/com/viaversion/viabackwards/api/ViaBackwardsPlatform.java
@@ -72,8 +72,8 @@ public interface ViaBackwardsPlatform {
     /**
      * Initialize ViaBackwards.
      */
-    default void init(File dataFolder) {
-        ViaBackwardsConfig config = new ViaBackwardsConfig(new File(dataFolder, "config.yml"));
+    default void init(final File configFile) {
+        ViaBackwardsConfig config = new ViaBackwardsConfig(configFile);
         config.reload();
         Via.getManager().getConfigurationProvider().register(config);
 

--- a/fabric/src/main/java/com/viaversion/viabackwards/ViaFabricAddon.java
+++ b/fabric/src/main/java/com/viaversion/viabackwards/ViaFabricAddon.java
@@ -34,7 +34,7 @@ public class ViaFabricAddon implements ViaBackwardsPlatform, Runnable {
     public void run() {
         Path configDirPath = FabricLoader.getInstance().getConfigDir().resolve("ViaBackwards");
         configDir = configDirPath.toFile();
-        this.init(getDataFolder());
+        this.init(new File(getDataFolder(), "config.yml"));
     }
 
     @Override

--- a/sponge/src/main/java/com/viaversion/viabackwards/SpongePlugin.java
+++ b/sponge/src/main/java/com/viaversion/viabackwards/SpongePlugin.java
@@ -47,7 +47,7 @@ public class SpongePlugin implements ViaBackwardsPlatform {
 
     @Listener
     public void constructPlugin(ConstructPluginEvent event) {
-        Via.getManager().addEnableListener(() -> this.init(getDataFolder()));
+        Via.getManager().addEnableListener(() -> this.init(new File(getDataFolder(), "config.yml")));
     }
 
     @Override

--- a/velocity/src/main/java/com/viaversion/viabackwards/VelocityPlugin.java
+++ b/velocity/src/main/java/com/viaversion/viabackwards/VelocityPlugin.java
@@ -52,7 +52,7 @@ public class VelocityPlugin implements ViaBackwardsPlatform {
     @Subscribe(order = PostOrder.LATE)
     public void onProxyStart(ProxyInitializeEvent event) {
         this.logger = new LoggerWrapper(loggerSlf4j);
-        Via.getManager().addEnableListener(() -> this.init(getDataFolder()));
+        Via.getManager().addEnableListener(() -> this.init(new File(getDataFolder(), "config.yml")));
     }
 
     @Override


### PR DESCRIPTION
Allows to fix the bug that in ViaProxy the VB config file is called "config.yml" because now we can rename it.