### PR TITLE
ChatUtil: Append unwritten formatting in prefix mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Known issues
   1.17 will not be able to see or interact with blocks below y=0 and above y=255
 * <1.17 clients on 1.17+ servers might experience inventory desyncs on certain inventory click actions
 * Sound mappings are incomplete ([see here](https://github.com/ViaVersion/ViaBackwards/issues/326))
+* <1.19.4 clients on 1.20+ servers won't be able to use the smithing table
 
 Other Links
 -

--- a/common/src/main/java/com/viaversion/viabackwards/utils/ChatUtil.java
+++ b/common/src/main/java/com/viaversion/viabackwards/utils/ChatUtil.java
@@ -128,6 +128,9 @@ public class ChatUtil {
             current = legacy.charAt(++i);
             lastState.processNextControlChar(current);
         }
+        if (isPrefix && !lastState.equals(builderState)) {
+            lastState.appendTo(builder);
+        }
         return builder.toString();
     }
 }


### PR DESCRIPTION
In prefix mode trailing formatting may be important for the component after the prefix. Because <1.12 clients will simply string concat prefix with the entityName