### PR TITLE
Implemented support for chat signing

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_18_2to1_19/storage/NonceStorage.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_18_2to1_19/storage/NonceStorage.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of ViaBackwards - https://github.com/ViaVersion/ViaBackwards
+ * Copyright (C) 2016-2023 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viabackwards.protocol.protocol1_18_2to1_19.storage;
+
+import com.viaversion.viaversion.api.connection.StorableObject;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public final class NonceStorage implements StorableObject {
+
+    private final byte[] nonce;
+
+    public NonceStorage(final byte @Nullable [] nonce) {
+        this.nonce = nonce;
+    }
+
+    public byte @Nullable [] nonce() {
+        return nonce;
+    }
+}

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_19_1to1_19_3/packets/EntityPackets1_19_3.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_19_1to1_19_3/packets/EntityPackets1_19_3.java
@@ -22,8 +22,9 @@ import com.viaversion.viabackwards.protocol.protocol1_19_1to1_19_3.Protocol1_19_
 import com.viaversion.viabackwards.protocol.protocol1_19_1to1_19_3.storage.ChatTypeStorage1_19_3;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.minecraft.ProfileKey;
-import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_19_3;
 import com.viaversion.viaversion.api.minecraft.entities.EntityType;
+import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_19_3;
+import com.viaversion.viaversion.api.minecraft.signature.storage.ChatSession1_19_3;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
 import com.viaversion.viaversion.api.type.Type;
@@ -37,9 +38,11 @@ import com.viaversion.viaversion.libs.opennbt.tag.builtin.NumberTag;
 import com.viaversion.viaversion.libs.opennbt.tag.builtin.Tag;
 import com.viaversion.viaversion.protocols.protocol1_19_1to1_19.ClientboundPackets1_19_1;
 import com.viaversion.viaversion.protocols.protocol1_19_3to1_19_1.ClientboundPackets1_19_3;
+import com.viaversion.viaversion.protocols.protocol1_19_3to1_19_1.ServerboundPackets1_19_3;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import java.util.BitSet;
 import java.util.UUID;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class EntityPackets1_19_3 extends EntityRewriter<ClientboundPackets1_19_3, Protocol1_19_1To1_19_3> {
 
@@ -85,6 +88,16 @@ public final class EntityPackets1_19_3 extends EntityRewriter<ClientboundPackets
                         final CompoundTag chatTypeCompound = (CompoundTag) chatType;
                         final NumberTag idTag = chatTypeCompound.get("id");
                         chatTypeStorage.addChatType(idTag.asInt(), chatTypeCompound);
+                    }
+                });
+                handler(wrapper -> {
+                    final ChatSession1_19_3 chatSession = wrapper.user().get(ChatSession1_19_3.class);
+
+                    if (chatSession != null) {
+                        final PacketWrapper chatSessionUpdate = wrapper.create(ServerboundPackets1_19_3.CHAT_SESSION_UPDATE);
+                        chatSessionUpdate.write(Type.UUID, chatSession.getSessionId());
+                        chatSessionUpdate.write(Type.PROFILE_KEY, chatSession.getProfileKey());
+                        chatSessionUpdate.sendToServer(Protocol1_19_1To1_19_3.class);
                     }
                 });
             }


### PR DESCRIPTION
Allows newer clients to chat on older servers which enforce signed chat. Also allows joining onto servers which require a secure game profile. Needs the client's private signing key. To use this one needs to put the ChatSession_X classes into a UserConnection before the login process.