### PR TITLE
Implement keep blocks explosion types

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_20_2to1_20_3/rewriter/BlockItemPacketRewriter1_20_3.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_20_2to1_20_3/rewriter/BlockItemPacketRewriter1_20_3.java
@@ -129,7 +129,7 @@ public final class BlockItemPacketRewriter1_20_3 extends ItemRewriter<Clientboun
             float knockbackY = wrapper.read(Type.FLOAT); // Knockback Y
             float knockbackZ = wrapper.read(Type.FLOAT); // Knockback Z
 
-            Integer blockInteraction = wrapper.read(Type.VAR_INT); // Block interaction type
+            int blockInteraction = wrapper.read(Type.VAR_INT); // Block interaction type
             // 0 = keep, 1 = destroy, 2 = destroy_with_decay, 3 = trigger_block
             if (blockInteraction == 1 || blockInteraction == 2) {
                 wrapper.write(Type.VAR_INT, blocks);


### PR DESCRIPTION
Checks the block interaction type of the explosion packet and removes the toBlow list if the explosion doesn't destroy blocks.
_(Not sure if there is any better way to peek at the block interaction type)_