### PR TITLE
Fixed wrong data type in JOIN_GAME handlers

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_1to1_16_2/packets/EntityPackets1_16_2.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_1to1_16_2/packets/EntityPackets1_16_2.java
@@ -22,20 +22,17 @@ import com.viaversion.viabackwards.ViaBackwards;
 import com.viaversion.viabackwards.api.rewriters.EntityRewriter;
 import com.viaversion.viabackwards.protocol.protocol1_16_1to1_16_2.Protocol1_16_1To1_16_2;
 import com.viaversion.viabackwards.protocol.protocol1_16_1to1_16_2.storage.BiomeStorage;
+import com.viaversion.viaversion.api.minecraft.entities.EntityType;
 import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_16;
 import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_16_2;
-import com.viaversion.viaversion.api.minecraft.entities.EntityType;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
 import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.types.version.Types1_16;
-import com.viaversion.viaversion.libs.opennbt.tag.builtin.CompoundTag;
-import com.viaversion.viaversion.libs.opennbt.tag.builtin.ListTag;
-import com.viaversion.viaversion.libs.opennbt.tag.builtin.NumberTag;
-import com.viaversion.viaversion.libs.opennbt.tag.builtin.StringTag;
-import com.viaversion.viaversion.libs.opennbt.tag.builtin.Tag;
+import com.viaversion.viaversion.libs.opennbt.tag.builtin.*;
 import com.viaversion.viaversion.protocols.protocol1_16_2to1_16_1.ClientboundPackets1_16_2;
 import com.viaversion.viaversion.protocols.protocol1_16to1_15_2.packets.EntityPackets;
+
 import java.util.Set;
 
 public class EntityPackets1_16_2 extends EntityRewriter<ClientboundPackets1_16_2, Protocol1_16_1To1_16_2> {
@@ -63,7 +60,7 @@ public class EntityPackets1_16_2 extends EntityRewriter<ClientboundPackets1_16_2
                 map(Type.INT); // Entity ID
                 handler(wrapper -> {
                     boolean hardcore = wrapper.read(Type.BOOLEAN);
-                    short gamemode = wrapper.read(Type.UNSIGNED_BYTE);
+                    short gamemode = wrapper.read(Type.BYTE);
                     if (hardcore) {
                         gamemode |= 0x08;
                     }

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/packets/EntityPackets1_17.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/packets/EntityPackets1_17.java
@@ -29,11 +29,7 @@ import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.types.version.Types1_16;
 import com.viaversion.viaversion.api.type.types.version.Types1_17;
-import com.viaversion.viaversion.libs.opennbt.tag.builtin.CompoundTag;
-import com.viaversion.viaversion.libs.opennbt.tag.builtin.IntTag;
-import com.viaversion.viaversion.libs.opennbt.tag.builtin.ListTag;
-import com.viaversion.viaversion.libs.opennbt.tag.builtin.StringTag;
-import com.viaversion.viaversion.libs.opennbt.tag.builtin.Tag;
+import com.viaversion.viaversion.libs.opennbt.tag.builtin.*;
 import com.viaversion.viaversion.protocols.protocol1_16_2to1_16_1.ClientboundPackets1_16_2;
 import com.viaversion.viaversion.protocols.protocol1_17to1_16_4.ClientboundPackets1_17;
 
@@ -68,16 +64,16 @@ public final class EntityPackets1_17 extends EntityRewriter<ClientboundPackets1_
             public void register() {
                 map(Type.INT); // Entity ID
                 map(Type.BOOLEAN); // Hardcore
-                map(Type.UNSIGNED_BYTE); // Gamemode
+                map(Type.BYTE); // Gamemode
                 map(Type.BYTE); // Previous Gamemode
                 map(Type.STRING_ARRAY); // Worlds
                 map(Type.NAMED_COMPOUND_TAG); // Dimension registry
                 map(Type.NAMED_COMPOUND_TAG); // Current dimension data
                 map(Type.STRING); // World
                 handler(wrapper -> {
-                    byte previousGamemode = wrapper.get(Type.BYTE, 0);
+                    byte previousGamemode = wrapper.get(Type.BYTE, 1);
                     if (previousGamemode == -1) { // "Unset" gamemode removed
-                        wrapper.set(Type.BYTE, 0, (byte) 0);
+                        wrapper.set(Type.BYTE, 1, (byte) 0);
                     }
                 });
                 handler(getTrackerHandler(EntityTypes1_17.PLAYER, Type.INT));

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_17_1to1_18/packets/EntityPackets1_18.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_17_1to1_18/packets/EntityPackets1_18.java
@@ -27,11 +27,7 @@ import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.types.version.Types1_17;
 import com.viaversion.viaversion.api.type.types.version.Types1_18;
-import com.viaversion.viaversion.libs.opennbt.tag.builtin.CompoundTag;
-import com.viaversion.viaversion.libs.opennbt.tag.builtin.FloatTag;
-import com.viaversion.viaversion.libs.opennbt.tag.builtin.ListTag;
-import com.viaversion.viaversion.libs.opennbt.tag.builtin.StringTag;
-import com.viaversion.viaversion.libs.opennbt.tag.builtin.Tag;
+import com.viaversion.viaversion.libs.opennbt.tag.builtin.*;
 import com.viaversion.viaversion.protocols.protocol1_18to1_17_1.ClientboundPackets1_18;
 
 public final class EntityPackets1_18 extends EntityRewriter<ClientboundPackets1_18, Protocol1_17_1To1_18> {
@@ -49,7 +45,7 @@ public final class EntityPackets1_18 extends EntityRewriter<ClientboundPackets1_
             public void register() {
                 map(Type.INT); // Entity ID
                 map(Type.BOOLEAN); // Hardcore
-                map(Type.UNSIGNED_BYTE); // Gamemode
+                map(Type.BYTE); // Gamemode
                 map(Type.BYTE); // Previous Gamemode
                 map(Type.STRING_ARRAY); // Worlds
                 map(Type.NAMED_COMPOUND_TAG); // Dimension registry

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_18_2to1_19/packets/EntityPackets1_19.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_18_2to1_19/packets/EntityPackets1_19.java
@@ -33,11 +33,7 @@ import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.types.version.Types1_18;
 import com.viaversion.viaversion.api.type.types.version.Types1_19;
-import com.viaversion.viaversion.libs.opennbt.tag.builtin.CompoundTag;
-import com.viaversion.viaversion.libs.opennbt.tag.builtin.ListTag;
-import com.viaversion.viaversion.libs.opennbt.tag.builtin.NumberTag;
-import com.viaversion.viaversion.libs.opennbt.tag.builtin.StringTag;
-import com.viaversion.viaversion.libs.opennbt.tag.builtin.Tag;
+import com.viaversion.viaversion.libs.opennbt.tag.builtin.*;
 import com.viaversion.viaversion.protocols.protocol1_18to1_17_1.ClientboundPackets1_18;
 import com.viaversion.viaversion.protocols.protocol1_19to1_18_2.ClientboundPackets1_19;
 
@@ -120,7 +116,7 @@ public final class EntityPackets1_19 extends EntityRewriter<ClientboundPackets1_
             public void register() {
                 map(Type.INT); // Entity ID
                 map(Type.BOOLEAN); // Hardcore
-                map(Type.UNSIGNED_BYTE); // Gamemode
+                map(Type.BYTE); // Gamemode
                 map(Type.BYTE); // Previous Gamemode
                 map(Type.STRING_ARRAY); // Worlds
                 map(Type.NAMED_COMPOUND_TAG); // Dimension registry

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_18to1_18_2/Protocol1_18To1_18_2.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_18to1_18_2/Protocol1_18To1_18_2.java
@@ -74,7 +74,7 @@ public final class Protocol1_18To1_18_2 extends BackwardsProtocol<ClientboundPac
             public void register() {
                 map(Type.INT); // Entity ID
                 map(Type.BOOLEAN); // Hardcore
-                map(Type.UNSIGNED_BYTE); // Gamemode
+                map(Type.BYTE); // Gamemode
                 map(Type.BYTE); // Previous Gamemode
                 map(Type.STRING_ARRAY); // World List
                 map(Type.NAMED_COMPOUND_TAG); // Registry

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_19_1to1_19_3/packets/EntityPackets1_19_3.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_19_1to1_19_3/packets/EntityPackets1_19_3.java
@@ -70,7 +70,7 @@ public final class EntityPackets1_19_3 extends EntityRewriter<ClientboundPackets
             public void register() {
                 map(Type.INT); // Entity id
                 map(Type.BOOLEAN); // Hardcore
-                map(Type.UNSIGNED_BYTE); // Gamemode
+                map(Type.BYTE); // Gamemode
                 map(Type.BYTE); // Previous Gamemode
                 map(Type.STRING_ARRAY); // World List
                 map(Type.NAMED_COMPOUND_TAG); // Dimension registry

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_19_3to1_19_4/packets/EntityPackets1_19_4.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_19_3to1_19_4/packets/EntityPackets1_19_4.java
@@ -20,8 +20,8 @@ package com.viaversion.viabackwards.protocol.protocol1_19_3to1_19_4.packets;
 import com.viaversion.viabackwards.api.entities.storage.EntityData;
 import com.viaversion.viabackwards.api.rewriters.EntityRewriter;
 import com.viaversion.viabackwards.protocol.protocol1_19_3to1_19_4.Protocol1_19_3To1_19_4;
-import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_19_4;
 import com.viaversion.viaversion.api.minecraft.entities.EntityType;
+import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_19_4;
 import com.viaversion.viaversion.api.minecraft.metadata.Metadata;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
 import com.viaversion.viaversion.api.type.Type;
@@ -49,7 +49,7 @@ public final class EntityPackets1_19_4 extends EntityRewriter<ClientboundPackets
             public void register() {
                 map(Type.INT); // Entity id
                 map(Type.BOOLEAN); // Hardcore
-                map(Type.UNSIGNED_BYTE); // Gamemode
+                map(Type.BYTE); // Gamemode
                 map(Type.BYTE); // Previous Gamemode
                 map(Type.STRING_ARRAY); // World List
                 map(Type.NAMED_COMPOUND_TAG); // Dimension registry

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_19_4to1_20/packets/EntityPackets1_20.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_19_4to1_20/packets/EntityPackets1_20.java
@@ -34,6 +34,7 @@ import com.viaversion.viaversion.libs.opennbt.tag.builtin.StringTag;
 import com.viaversion.viaversion.libs.opennbt.tag.builtin.Tag;
 import com.viaversion.viaversion.protocols.protocol1_19_4to1_19_3.ClientboundPackets1_19_4;
 import com.viaversion.viaversion.util.Key;
+
 import java.util.Set;
 
 public final class EntityPackets1_20 extends EntityRewriter<ClientboundPackets1_19_4, Protocol1_19_4To1_20> {
@@ -57,7 +58,7 @@ public final class EntityPackets1_20 extends EntityRewriter<ClientboundPackets1_
             public void register() {
                 map(Type.INT); // Entity id
                 map(Type.BOOLEAN); // Hardcore
-                map(Type.UNSIGNED_BYTE); // Gamemode
+                map(Type.BYTE); // Gamemode
                 map(Type.BYTE); // Previous Gamemode
                 map(Type.STRING_ARRAY); // World List
                 map(Type.NAMED_COMPOUND_TAG); // Dimension registry

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_19to1_19_1/Protocol1_19To1_19_1.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_19to1_19_1/Protocol1_19To1_19_1.java
@@ -96,7 +96,7 @@ public final class Protocol1_19To1_19_1 extends BackwardsProtocol<ClientboundPac
             public void register() {
                 map(Type.INT); // Entity ID
                 map(Type.BOOLEAN); // Hardcore
-                map(Type.UNSIGNED_BYTE); // Gamemode
+                map(Type.BYTE); // Gamemode
                 map(Type.BYTE); // Previous Gamemode
                 map(Type.STRING_ARRAY); // World List
                 map(Type.NAMED_COMPOUND_TAG); // Dimension registry

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_20to1_20_2/rewriter/EntityPacketRewriter1_20_2.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_20to1_20_2/rewriter/EntityPacketRewriter1_20_2.java
@@ -124,7 +124,7 @@ public final class EntityPacketRewriter1_20_2 extends EntityRewriter<Clientbound
                     final String world = wrapper.read(Type.STRING);
                     final long seed = wrapper.read(Type.LONG);
 
-                    wrapper.write(Type.UNSIGNED_BYTE, wrapper.read(Type.BYTE).shortValue()); // Gamemode
+                    wrapper.passthrough(Type.BYTE); // Gamemode
                     wrapper.passthrough(Type.BYTE); // Previous gamemode
 
                     wrapper.write(Type.STRING_ARRAY, worlds);


### PR DESCRIPTION
This PR uses the correct data type for reading the gamemode in the JOIN_GAME handlers.
Vanilla client code:
![image](https://github.com/ViaVersion/ViaVersion/assets/50594595/75d3aa3a-801f-4db6-b05c-f886f3550eac)
