### PR TITLE
Handle GameState 13 in 1.20.2 -> 1.20.3 correctly.

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_20_2to1_20_3/Protocol1_20_2To1_20_3.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_20_2to1_20_3/Protocol1_20_2To1_20_3.java
@@ -24,7 +24,9 @@ import com.viaversion.viabackwards.api.rewriters.TranslatableRewriter;
 import com.viaversion.viabackwards.protocol.protocol1_20_2to1_20_3.rewriter.BlockItemPacketRewriter1_20_3;
 import com.viaversion.viabackwards.protocol.protocol1_20_2to1_20_3.rewriter.EntityPacketRewriter1_20_3;
 import com.viaversion.viabackwards.protocol.protocol1_20_2to1_20_3.storage.ResourcepackIDStorage;
+import com.viaversion.viabackwards.protocol.protocol1_20_2to1_20_3.storage.SpawnPositionStorage;
 import com.viaversion.viaversion.api.connection.UserConnection;
+import com.viaversion.viaversion.api.minecraft.Position;
 import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_20_3;
 import com.viaversion.viaversion.api.protocol.packet.ClientboundPacketType;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
@@ -34,6 +36,7 @@ import com.viaversion.viaversion.api.protocol.remapper.PacketHandler;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
 import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.data.entity.EntityTrackerBase;
+import com.viaversion.viaversion.libs.fastutil.Pair;
 import com.viaversion.viaversion.libs.opennbt.tag.builtin.Tag;
 import com.viaversion.viaversion.protocols.protocol1_19_4to1_19_3.rewriter.CommandRewriter1_19_4;
 import com.viaversion.viaversion.protocols.protocol1_20_2to1_20.packet.ClientboundConfigurationPackets1_20_2;
@@ -47,6 +50,7 @@ import com.viaversion.viaversion.protocols.protocol1_20_3to1_20_2.packet.Serverb
 import com.viaversion.viaversion.rewriter.ComponentRewriter.ReadType;
 import com.viaversion.viaversion.rewriter.StatisticsRewriter;
 import com.viaversion.viaversion.rewriter.TagRewriter;
+
 import java.util.BitSet;
 import java.util.UUID;
 
@@ -307,6 +311,25 @@ public final class Protocol1_20_2To1_20_3 extends BackwardsProtocol<ClientboundP
                 }
             }
         });
+        registerClientbound(ClientboundPackets1_20_3.SPAWN_POSITION, wrapper -> {
+            final Position position = wrapper.passthrough(Type.POSITION1_14);
+            final float angle = wrapper.passthrough(Type.FLOAT);
+            wrapper.user().get(SpawnPositionStorage.class).setSpawnPosition(position, angle);
+        });
+        registerClientbound(ClientboundPackets1_20_3.GAME_EVENT, wrapper -> {
+            final short reason = wrapper.passthrough(Type.UNSIGNED_BYTE);
+            if (reason == 13) { // Initial chunk coming
+                wrapper.cancel();
+                final Pair<Position, Float> spawnPositionAndAngle = wrapper.user().get(SpawnPositionStorage.class).getSpawnPosition();
+
+                // To emulate the old behavior, we send a fake spawn pos packet containing the actual spawn pos which forces
+                // the 1.20.2 client to close the downloading terrain screen like the new game state does
+                final PacketWrapper spawnPosition = wrapper.create(ClientboundPackets1_20_2.SPAWN_POSITION);
+                spawnPosition.write(Type.POSITION1_14, spawnPositionAndAngle.first()); // position
+                spawnPosition.write(Type.FLOAT, spawnPositionAndAngle.second()); // angle
+                spawnPosition.send(Protocol1_20_2To1_20_3.class, true);
+            }
+        });
 
         cancelClientbound(ClientboundPackets1_20_3.RESOURCE_PACK_POP);
         registerServerbound(ServerboundPackets1_20_2.RESOURCE_PACK_STATUS, resourcePackStatusHandler());
@@ -353,6 +376,7 @@ public final class Protocol1_20_2To1_20_3 extends BackwardsProtocol<ClientboundP
 
     @Override
     public void init(final UserConnection connection) {
+        connection.put(new SpawnPositionStorage());
         addEntityTracker(connection, new EntityTrackerBase(connection, EntityTypes1_20_3.PLAYER));
     }
 

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_20_2to1_20_3/storage/SpawnPositionStorage.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_20_2to1_20_3/storage/SpawnPositionStorage.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of ViaBackwards - https://github.com/ViaVersion/ViaBackwards
+ * Copyright (C) 2023 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viabackwards.protocol.protocol1_20_2to1_20_3.storage;
+
+import com.viaversion.viaversion.api.connection.StorableObject;
+import com.viaversion.viaversion.api.minecraft.Position;
+import com.viaversion.viaversion.libs.fastutil.Pair;
+
+public class SpawnPositionStorage implements StorableObject {
+
+    private Pair<Position, Float> spawnPosition = Pair.of(new Position(8, 64, 8), 0.0F); // Default values copied from the original client
+
+    public Pair<Position, Float> getSpawnPosition() {
+        return spawnPosition;
+    }
+
+    public void setSpawnPosition(final Position position, final float angle) {
+        this.spawnPosition = Pair.of(position, angle);
+    }
+
+}


### PR DESCRIPTION
This PR handles the new game state for closing the downloading terrain screen correctly.