### PR TITLE
use legacy version in 1.13 item rewriter

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_13to1_13_1/packets/InventoryPackets1_13_1.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_13to1_13_1/packets/InventoryPackets1_13_1.java
@@ -27,7 +27,7 @@ import com.viaversion.viaversion.rewriter.ItemRewriter;
 public class InventoryPackets1_13_1 extends ItemRewriter<ClientboundPackets1_13, ServerboundPackets1_13, Protocol1_13To1_13_1> {
 
     public InventoryPackets1_13_1(Protocol1_13To1_13_1 protocol) {
-        super(protocol);
+        super(protocol, Type.ITEM1_13, Type.ITEM1_13_2_ARRAY);
     }
 
     @Override


### PR DESCRIPTION
This PR specifies the correct types for pre 1.13.2 items. 

Currently ViaBackwards defaults to `Type.ITEM_1_13_2 & Type.ITEM1_13_2_Array` (https://github.com/ViaVersion/ViaBackwards/blob/master/common/src/main/java/com/viaversion/viabackwards/api/rewriters/ItemRewriterBase.java#L39) but Type.ITEM_1_13_2 does not exist in these lower versions. 

Full Exception:
```
[04:30:13 WARN]: [ViaVersion] ERROR IN Protocol1_13To1_13_1 IN REMAP OF SPAWN_PARTICLE (0x24)
[04:30:13 WARN]: io.netty.handler.codec.EncoderException: com.viaversion.viaversion.exception.InformativeException: Please report this on the Via support Discord or open an issue on the relevant GitHub repository
[04:30:13 WARN]: Packet Type: SPAWN_PARTICLE, Type: ItemType1_13_2, Index: 0, Data: [{IntType: 27}, {BooleanType: true}, {FloatType: 797.5}, {FloatType: 85.41}, {FloatType: 1.5}, {FloatType: 0.3}, {FloatType: 0.4}, {FloatType: 0.3}, {FloatType: 0.0}, {IntType: 2}], Source 0: com.viaversion.viaversion.rewriter.ItemRewriter$12 (Anonymous), Packet ID: 36
[04:30:13 WARN]:        at io.netty.handler.codec.MessageToMessageEncoder.write(MessageToMessageEncoder.java:107)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:881)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:863)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:968)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:856)
[04:30:13 WARN]:        at io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:113)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:881)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:863)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:968)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:856)
[04:30:13 WARN]:        at io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:120)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:881)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:863)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:968)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:856)
[04:30:13 WARN]:        at io.netty.handler.codec.MessageToMessageEncoder.write(MessageToMessageEncoder.java:113)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:881)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:863)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:968)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:856)
[04:30:13 WARN]:        at io.netty.channel.ChannelDuplexHandler.write(ChannelDuplexHandler.java:115)
[04:30:13 WARN]:        at OldCombatMechanics.jar//kernitus.plugin.OldCombatMechanics.utilities.packet.mitm.PacketInjector.write(PacketInjector.java:196)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:879)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:940)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:966)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:934)
[04:30:13 WARN]:        at io.netty.channel.DefaultChannelPipeline.writeAndFlush(DefaultChannelPipeline.java:1020)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannel.writeAndFlush(AbstractChannel.java:311)
[04:30:13 WARN]:        at ProtocolLib.jar//com.comphenix.protocol.injector.netty.channel.NettyChannelProxy.writeAndFlush(NettyChannelProxy.java:227)
[04:30:13 WARN]:        at ProtocolLib.jar//com.comphenix.protocol.injector.netty.channel.NettyChannelProxy.writeAndFlush(NettyChannelProxy.java:233)
[04:30:13 WARN]:        at net.minecraft.network.NetworkManager.doSendPacket(NetworkManager.java:469)
[04:30:13 WARN]:        at net.minecraft.network.NetworkManager.lambda$sendPacket$11(NetworkManager.java:443)
[04:30:13 WARN]:        at ProtocolLib.jar//com.comphenix.protocol.injector.netty.channel.NettyEventLoopProxy.lambda$proxyRunnable$2(NettyEventLoopProxy.java:48)
[04:30:13 WARN]:        at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174)
[04:30:13 WARN]:        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167)
[04:30:13 WARN]:        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
[04:30:13 WARN]:        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
[04:30:13 WARN]:        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
[04:30:13 WARN]:        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
[04:30:13 WARN]:        at java.base/java.lang.Thread.run(Thread.java:833)
[04:30:13 WARN]: Caused by: com.viaversion.viaversion.exception.InformativeException: Please report this on the Via support Discord or open an issue on the relevant GitHub repository
[04:30:13 WARN]: Packet Type: SPAWN_PARTICLE, Type: ItemType1_13_2, Index: 0, Data: [{IntType: 27}, {BooleanType: true}, {FloatType: 797.5}, {FloatType: 85.41}, {FloatType: 1.5}, {FloatType: 0.3}, {FloatType: 0.4}, {FloatType: 0.3}, {FloatType: 0.0}, {IntType: 2}], Source 0: com.viaversion.viaversion.rewriter.ItemRewriter$12 (Anonymous), Packet ID: 36
[04:30:13 WARN]: Caused by: java.io.IOException: Unable to read type ItemType1_13_2, found ItemType1_13
[04:30:13 WARN]:        at ViaVersion.jar//com.viaversion.viaversion.protocol.packet.PacketWrapperImpl.read(PacketWrapperImpl.java:156)
[04:30:13 WARN]:        at ViaVersion.jar//com.viaversion.viaversion.protocol.packet.PacketWrapperImpl.passthrough(PacketWrapperImpl.java:187)
[04:30:13 WARN]:        at ViaVersion.jar//com.viaversion.viaversion.rewriter.ItemRewriter.lambda$getSpawnParticleHandler$5(ItemRewriter.java:439)
[04:30:13 WARN]:        at ViaVersion.jar//com.viaversion.viaversion.api.protocol.remapper.PacketHandlers.handle(PacketHandlers.java:158)
[04:30:13 WARN]:        at ViaVersion.jar//com.viaversion.viaversion.api.protocol.AbstractProtocol.transform(AbstractProtocol.java:392)
[04:30:13 WARN]:        at ViaVersion.jar//com.viaversion.viaversion.protocol.packet.PacketWrapperImpl.apply(PacketWrapperImpl.java:423)
[04:30:13 WARN]:        at ViaVersion.jar//com.viaversion.viaversion.protocol.packet.PacketWrapperImpl.apply(PacketWrapperImpl.java:407)
[04:30:13 WARN]:        at ViaVersion.jar//com.viaversion.viaversion.protocol.packet.PacketWrapperImpl.apply(PacketWrapperImpl.java:46)
[04:30:13 WARN]:        at ViaVersion.jar//com.viaversion.viaversion.protocol.ProtocolPipelineImpl.transform(ProtocolPipelineImpl.java:115)
[04:30:13 WARN]:        at ViaVersion.jar//com.viaversion.viaversion.connection.UserConnectionImpl.transform(UserConnectionImpl.java:330)
[04:30:13 WARN]:        at ViaVersion.jar//com.viaversion.viaversion.connection.UserConnectionImpl.transformClientbound(UserConnectionImpl.java:308)
[04:30:13 WARN]:        at ViaVersion.jar//com.viaversion.viaversion.bukkit.handlers.BukkitEncodeHandler.encode(BukkitEncodeHandler.java:57)
[04:30:13 WARN]:        at ViaVersion.jar//com.viaversion.viaversion.bukkit.handlers.BukkitEncodeHandler.encode(BukkitEncodeHandler.java:35)
[04:30:13 WARN]:        at io.netty.handler.codec.MessageToMessageEncoder.write(MessageToMessageEncoder.java:90)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:881)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:863)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:968)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:856)
[04:30:13 WARN]:        at io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:113)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:881)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:863)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:968)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:856)
[04:30:13 WARN]:        at io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:120)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:881)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:863)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:968)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:856)
[04:30:13 WARN]:        at io.netty.handler.codec.MessageToMessageEncoder.write(MessageToMessageEncoder.java:113)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:881)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:863)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:968)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:856)
[04:30:13 WARN]:        at io.netty.channel.ChannelDuplexHandler.write(ChannelDuplexHandler.java:115)
[04:30:13 WARN]:        at OldCombatMechanics.jar//kernitus.plugin.OldCombatMechanics.utilities.packet.mitm.PacketInjector.write(PacketInjector.java:196)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:879)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:940)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:966)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:934)
[04:30:13 WARN]:        at io.netty.channel.DefaultChannelPipeline.writeAndFlush(DefaultChannelPipeline.java:1020)
[04:30:13 WARN]:        at io.netty.channel.AbstractChannel.writeAndFlush(AbstractChannel.java:311)
[04:30:13 WARN]:        at ProtocolLib.jar//com.comphenix.protocol.injector.netty.channel.NettyChannelProxy.writeAndFlush(NettyChannelProxy.java:227)
[04:30:13 WARN]:        at ProtocolLib.jar//com.comphenix.protocol.injector.netty.channel.NettyChannelProxy.writeAndFlush(NettyChannelProxy.java:233)
[04:30:13 WARN]:        at net.minecraft.network.NetworkManager.doSendPacket(NetworkManager.java:469)
[04:30:13 WARN]:        at net.minecraft.network.NetworkManager.lambda$sendPacket$11(NetworkManager.java:443)
[04:30:13 WARN]:        at ProtocolLib.jar//com.comphenix.protocol.injector.netty.channel.NettyEventLoopProxy.lambda$proxyRunnable$2(NettyEventLoopProxy.java:48)
[04:30:13 WARN]:        at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174)
[04:30:13 WARN]:        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167)
[04:30:13 WARN]:        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
[04:30:13 WARN]:        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
[04:30:13 WARN]:        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
[04:30:13 WARN]:        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
[04:30:13 WARN]:        at java.base/java.lang.Thread.run(Thread.java:833)
```