### PR TITLE
Fix display entities causing crashes on 1.19.3 and below

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_19_3to1_19_4/packets/EntityPackets1_19_4.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_19_3to1_19_4/packets/EntityPackets1_19_4.java
@@ -132,6 +132,7 @@ public final class EntityPackets1_19_4 extends EntityRewriter<ClientboundPackets
         filter().handler((event, meta) -> {
             int id = meta.metaType().typeId();
             if (id >= 25) { // Sniffer state, Vector3f, Quaternion types
+                event.cancel();
                 return;
             } else if (id >= 15) { // Optional block state - just map down to block state
                 id--;


### PR DESCRIPTION
Seems like this was removed in 8715c243c92d5dcabe9b39f077c9eb0101773b1a and I'm not seeing any reason to do so? Not removing it causes problems downstream.