### PR TITLE
Fix 1.20.2 configuration ping packet handling

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_20to1_20_2/Protocol1_20To1_20_2.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_20to1_20_2/Protocol1_20To1_20_2.java
@@ -119,7 +119,11 @@ public final class Protocol1_20To1_20_2 extends BackwardsProtocol<ClientboundPac
             wrapper.setPacketType(ClientboundPackets1_19_4.KEEP_ALIVE);
         });
         registerClientbound(State.CONFIGURATION, ClientboundConfigurationPackets1_20_2.PING.getId(), -1, wrapper -> {
-            wrapper.setPacketType(ClientboundPackets1_19_4.PING);
+            wrapper.cancel();
+
+            final PacketWrapper pingResponse = wrapper.create(ServerboundConfigurationPackets1_20_2.PONG);
+            pingResponse.write(Type.INT, wrapper.read(Type.INT));
+            pingResponse.sendToServer(Protocol1_20To1_20_2.class);
         });
         registerClientbound(State.CONFIGURATION, ClientboundConfigurationPackets1_20_2.RESOURCE_PACK.getId(), -1, wrapper -> {
             // Send after join. We have to pretend the client accepted, else the server won't continue...
@@ -177,8 +181,6 @@ public final class Protocol1_20To1_20_2 extends BackwardsProtocol<ClientboundPac
             wrapper.setPacketType(ServerboundConfigurationPackets1_20_2.CUSTOM_PAYLOAD);
         } else if (id == ServerboundPackets1_19_4.KEEP_ALIVE.getId()) {
             wrapper.setPacketType(ServerboundConfigurationPackets1_20_2.KEEP_ALIVE);
-        } else if (id == ServerboundPackets1_19_4.PONG.getId()) {
-            wrapper.setPacketType(ServerboundConfigurationPackets1_20_2.PONG);
         } else if (id == ServerboundPackets1_19_4.RESOURCE_PACK_STATUS.getId()) {
             wrapper.setPacketType(ServerboundConfigurationPackets1_20_2.RESOURCE_PACK);
         } else {


### PR DESCRIPTION
 1.20.1- clients (even vanilla) currently times out when join 1.20.2+ fabric servers with fabric api installed.

The client really does not have a way of sending pong in this stage. Even if it does, the current implementation is still broken as play state ping packet has a LONG payload instead of a INT one.