### PR TITLE
Expose EntityRewriterBase#alwaysShowOriginalMobName

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/api/rewriters/EntityRewriterBase.java
+++ b/common/src/main/java/com/viaversion/viabackwards/api/rewriters/EntityRewriterBase.java
@@ -103,10 +103,14 @@ public abstract class EntityRewriterBase<C extends ClientboundPacketType, T exte
     }
 
     private void addDisplayVisibilityMeta(List<Metadata> metadataList) {
-        if (ViaBackwards.getConfig().alwaysShowOriginalMobName()) {
+        if (alwaysShowOriginalMobName()) {
             removeMeta(displayVisibilityIndex, metadataList);
             metadataList.add(new Metadata(displayVisibilityIndex, displayVisibilityMetaType, true));
         }
+    }
+
+    protected boolean alwaysShowOriginalMobName() {
+        return ViaBackwards.getConfig().alwaysShowOriginalMobName();
     }
 
     protected @Nullable Metadata getMeta(int metaIndex, List<Metadata> metadataList) {


### PR DESCRIPTION
Allows platforms using the entity rewriter base to override the config value with their own one