### PR TITLE
 Rework legacy item/block mappings format

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/api/data/MappedLegacyBlockItem.java
+++ b/common/src/main/java/com/viaversion/viabackwards/api/data/MappedLegacyBlockItem.java
@@ -27,13 +27,19 @@ public class MappedLegacyBlockItem {
     private final short data;
     private final String name;
     private final IdAndData block;
+    private final Type type;
     private BlockEntityHandler blockEntityHandler;
 
-    public MappedLegacyBlockItem(int id, short data, @Nullable String name, boolean block) {
+    public MappedLegacyBlockItem(int id) {
+        this(id, (short) -1, null, Type.ITEM);
+    }
+
+    public MappedLegacyBlockItem(int id, short data, @Nullable String name, Type type) {
         this.id = id;
         this.data = data;
         this.name = name != null ? "§f" + name : null;
-        this.block = block ? data != -1 ? new IdAndData(id, data) : new IdAndData(id) : null;
+        this.block = type != Type.ITEM ? data != -1 ? new IdAndData(id, data) : new IdAndData(id) : null;
+        this.type = type;
     }
 
     public int getId() {
@@ -48,8 +54,8 @@ public class MappedLegacyBlockItem {
         return name;
     }
 
-    public boolean isBlock() {
-        return block != null;
+    public Type getType() {
+        return type;
     }
 
     public IdAndData getBlock() {
@@ -72,5 +78,22 @@ public class MappedLegacyBlockItem {
     public interface BlockEntityHandler {
 
         CompoundTag handleOrNewCompoundTag(int block, CompoundTag tag);
+    }
+
+    public enum Type {
+
+        ITEM("items"),
+        BLOCK_ITEM("block-items"),
+        BLOCK("blocks");
+
+        final String name;
+
+        Type(final String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
     }
 }

--- a/common/src/main/java/com/viaversion/viabackwards/api/rewriters/LegacyBlockItemRewriter.java
+++ b/common/src/main/java/com/viaversion/viabackwards/api/rewriters/LegacyBlockItemRewriter.java
@@ -153,7 +153,7 @@ public abstract class LegacyBlockItemRewriter<C extends ClientboundPacketType, S
         if (item == null) return null;
 
         MappedLegacyBlockItem data = getMappedBlockItem(item.identifier(), item.data());
-        if (data == null) {
+        if (data == null || data.getType() == MappedLegacyBlockItem.Type.BLOCK) {
             // Just rewrite the id
             return super.handleItemToClient(connection, item);
         }
@@ -226,7 +226,9 @@ public abstract class LegacyBlockItemRewriter<C extends ClientboundPacketType, S
 
     public @Nullable IdAndData handleBlock(int blockId, int data) {
         MappedLegacyBlockItem settings = getMappedBlockItem(blockId, data);
-        if (settings == null || settings.getType() == MappedLegacyBlockItem.Type.ITEM) return null;
+        if (settings == null || settings.getType() == MappedLegacyBlockItem.Type.ITEM) {
+            return null;
+        }
 
         IdAndData block = settings.getBlock();
         // For some blocks, the data can still be useful (:

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_10to1_11/packets/BlockItemPackets1_11.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_10to1_11/packets/BlockItemPackets1_11.java
@@ -274,7 +274,7 @@ public class BlockItemPackets1_11 extends LegacyBlockItemRewriter<ClientboundPac
     @Override
     protected void registerRewrites() {
         // Handle spawner block entity (map to itself with custom handler)
-        MappedLegacyBlockItem data = replacementData.computeIfAbsent(IdAndData.toRawData(52), s -> new MappedLegacyBlockItem(52, (short) -1, null, false));
+        MappedLegacyBlockItem data = replacementData.computeIfAbsent(IdAndData.toRawData(52), s -> new MappedLegacyBlockItem(52));
         data.setBlockEntityHandler((b, tag) -> {
             EntityIdRewriter.toClientSpawner(tag, true);
             return tag;

--- a/common/src/main/resources/assets/viabackwards/data/item-mappings-1.10.json
+++ b/common/src/main/resources/assets/viabackwards/data/item-mappings-1.10.json
@@ -1,33 +1,32 @@
 {
-  "255": {
-    "id": 217,
-    "name": "1.10 Structure Block"
+  "items": {
+    "255": {
+      "id": 217,
+      "name": "1.10 Structure Block"
+    }
   },
-  "217": {
-    "id": 287,
-    "name": "1.10 Structure Void",
-    "block": true
-  },
-  "213": {
-    "id": 159,
-    "data": 1,
-    "name": "1.10 Magma Block",
-    "block": true
-  },
-  "214": {
-    "id": 159,
-    "data": 14,
-    "name": "1.10 Nether Wart Block",
-    "block": true
-  },
-  "215": {
-    "id": 112,
-    "name": "1.10 Red Nether Bricks",
-    "block": true
-  },
-  "216": {
-    "id": 155,
-    "name": "1.10 Bone Block",
-    "block": true
+  "block-items": {
+    "217": {
+      "id": 287,
+      "name": "1.10 Structure Void"
+    },
+    "213": {
+      "id": 159,
+      "data": 1,
+      "name": "1.10 Magma Block"
+    },
+    "214": {
+      "id": 159,
+      "data": 14,
+      "name": "1.10 Nether Wart Block"
+    },
+    "215": {
+      "id": 112,
+      "name": "1.10 Red Nether Bricks"
+    },
+    "216": {
+      "id": 155,
+      "name": "1.10 Bone Block"
+    }
   }
 }

--- a/common/src/main/resources/assets/viabackwards/data/item-mappings-1.11.1.json
+++ b/common/src/main/resources/assets/viabackwards/data/item-mappings-1.11.1.json
@@ -1,6 +1,8 @@
 {
-  "452": {
-    "id": 265,
-    "name": "1.11.1 Iron Nugget"
+  "items": {
+    "452": {
+      "id": 265,
+      "name": "1.11.1 Iron Nugget"
+    }
   }
 }

--- a/common/src/main/resources/assets/viabackwards/data/item-mappings-1.11.json
+++ b/common/src/main/resources/assets/viabackwards/data/item-mappings-1.11.json
@@ -1,21 +1,23 @@
 {
-  "218": {
-    "id": 23,
-    "data": -1,
-    "name": "1.11 Observer",
-    "block": true
+  "items": {
+    "449": {
+      "id": 418,
+      "name": "1.11 Totem of Undying"
+    },
+    "450": {
+      "id": 433,
+      "name": "1.11 Shulker Shell"
+    }
   },
-  "449": {
-    "id": 418,
-    "name": "1.11 Totem of Undying"
-  },
-  "450": {
-    "id": 433,
-    "name": "1.11 Shulker Shell"
-  },
-  "219-234": {
-    "id": 158,
-    "name": "1.11 %color% Shulker Box",
-    "block": true
+  "block-items": {
+    "218": {
+      "id": 23,
+      "data": -1,
+      "name": "1.11 Observer"
+    },
+    "219-234": {
+      "id": 158,
+      "name": "1.11 %color% Shulker Box"
+    }
   }
 }

--- a/common/src/main/resources/assets/viabackwards/data/item-mappings-1.12.json
+++ b/common/src/main/resources/assets/viabackwards/data/item-mappings-1.12.json
@@ -1,27 +1,28 @@
 {
-  "251": {
-    "id": 159,
-    "data": -1,
-    "name": "1.12 %vb_color% Concrete",
-    "block": true
+  "items": {
+    "453": {
+      "id": 340,
+      "name": "1.12 Knowledge Book"
+    },
+    "355": {
+      "id": 355,
+      "name": "1.12 %vb_color% Bed"
+    }
   },
-  "252": {
-    "id": 35,
-    "data": -1,
-    "name": "1.12 %vb_color% Concrete Powder",
-    "block": true
-  },
-  "453": {
-    "id": 340,
-    "name": "1.12 Knowledge Book"
-  },
-  "355": {
-    "id": 355,
-    "name": "1.12 %vb_color% Bed"
-  },
-  "235-250": {
-    "id": 159,
-    "name": "1.12 %color% Glazed Terracotta",
-    "block": true
+  "block-items": {
+    "251": {
+      "id": 159,
+      "data": -1,
+      "name": "1.12 %vb_color% Concrete"
+    },
+    "252": {
+      "id": 35,
+      "data": -1,
+      "name": "1.12 %vb_color% Concrete Powder"
+    },
+    "235-250": {
+      "id": 159,
+      "name": "1.12 %color% Glazed Terracotta"
+    }
   }
 }


### PR DESCRIPTION
Mainly done because ViaRewind needs blockstate mappings, following changes are included:
- Removed "block" value and instead moved item only and item/block mappings into separate json objects
- Added "blocks" json object for block only/blockstate mappings (required for ViaRewind)
- Added MappedLegacyBlockItem constructor with only the id

This changes (combined with the previous split of legacy mappings into multiple files, see https://github.com/ViaVersion/ViaBackwards/pull/703) should be noted in the upcoming release notes.
If you don't mind, I'll also update VB's wiki page to these changes later.