### PR TITLE
Add support for different mapping types with same id

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/api/data/MappedLegacyBlockItem.java
+++ b/common/src/main/java/com/viaversion/viabackwards/api/data/MappedLegacyBlockItem.java
@@ -27,7 +27,6 @@ public class MappedLegacyBlockItem {
     private final short data;
     private final String name;
     private final IdAndData block;
-    private final Type type;
     private BlockEntityHandler blockEntityHandler;
 
     public MappedLegacyBlockItem(int id) {
@@ -39,7 +38,6 @@ public class MappedLegacyBlockItem {
         this.data = data;
         this.name = name != null ? "§f" + name : null;
         this.block = type != Type.ITEM ? data != -1 ? new IdAndData(id, data) : new IdAndData(id) : null;
-        this.type = type;
     }
 
     public int getId() {
@@ -52,10 +50,6 @@ public class MappedLegacyBlockItem {
 
     public String getName() {
         return name;
-    }
-
-    public Type getType() {
-        return type;
     }
 
     public IdAndData getBlock() {

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_10to1_11/packets/BlockItemPackets1_11.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_10to1_11/packets/BlockItemPackets1_11.java
@@ -274,7 +274,7 @@ public class BlockItemPackets1_11 extends LegacyBlockItemRewriter<ClientboundPac
     @Override
     protected void registerRewrites() {
         // Handle spawner block entity (map to itself with custom handler)
-        MappedLegacyBlockItem data = replacementData.computeIfAbsent(IdAndData.toRawData(52), s -> new MappedLegacyBlockItem(52));
+        MappedLegacyBlockItem data = itemReplacements.computeIfAbsent(IdAndData.toRawData(52), s -> new MappedLegacyBlockItem(52));
         data.setBlockEntityHandler((b, tag) -> {
             EntityIdRewriter.toClientSpawner(tag, true);
             return tag;


### PR DESCRIPTION
ViaRewind needs item and block mappings with the same id/data (1.8->1.9, end_rod) so decided to split both mappings into different lists, block items are merged into both lists on load.

Closes https://github.com/ViaVersion/ViaRewind/issues/507