### PR TITLE
Make chat_types handling in 1.19 protocols optional

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_19_1to1_19_3/packets/EntityPackets1_19_3.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_19_1to1_19_3/packets/EntityPackets1_19_3.java
@@ -83,7 +83,7 @@ public final class EntityPackets1_19_3 extends EntityRewriter<ClientboundPackets
                     chatTypeStorage.clear();
 
                     final CompoundTag registry = wrapper.get(Type.NAMED_COMPOUND_TAG, 0);
-                    final ListTag<CompoundTag> chatTypes = TagUtil.getRegistryEntries(registry, "chat_type");
+                    final ListTag<CompoundTag> chatTypes = TagUtil.getOptionalRegistryEntries(registry, "chat_type");
                     for (final CompoundTag chatType : chatTypes) {
                         final NumberTag idTag = chatType.getNumberTag("id");
                         chatTypeStorage.addChatType(idTag.asInt(), chatType);

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_19_1to1_19_3/packets/EntityPackets1_19_3.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_19_1to1_19_3/packets/EntityPackets1_19_3.java
@@ -83,7 +83,7 @@ public final class EntityPackets1_19_3 extends EntityRewriter<ClientboundPackets
                     chatTypeStorage.clear();
 
                     final CompoundTag registry = wrapper.get(Type.NAMED_COMPOUND_TAG, 0);
-                    final ListTag<CompoundTag> chatTypes = TagUtil.getOptionalRegistryEntries(registry, "chat_type");
+                    final ListTag<CompoundTag> chatTypes = TagUtil.getRegistryEntries(registry, "chat_type", new ListTag<>(CompoundTag.class));
                     for (final CompoundTag chatType : chatTypes) {
                         final NumberTag idTag = chatType.getNumberTag("id");
                         chatTypeStorage.addChatType(idTag.asInt(), chatType);

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_19to1_19_1/Protocol1_19To1_19_1.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_19to1_19_1/Protocol1_19To1_19_1.java
@@ -103,7 +103,7 @@ public final class Protocol1_19To1_19_1 extends BackwardsProtocol<ClientboundPac
                     chatTypeStorage.clear();
 
                     final CompoundTag registry = wrapper.get(Type.NAMED_COMPOUND_TAG, 0);
-                    final ListTag<CompoundTag> chatTypes = TagUtil.removeOptionalRegistryEntries(registry, "chat_type");
+                    final ListTag<CompoundTag> chatTypes = TagUtil.removeRegistryEntries(registry, "chat_type", new ListTag<>(CompoundTag.class));
                     for (final CompoundTag chatType : chatTypes) {
                         final NumberTag idTag = chatType.getNumberTag("id");
                         chatTypeStorage.addChatType(idTag.asInt(), chatType);

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_19to1_19_1/Protocol1_19To1_19_1.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_19to1_19_1/Protocol1_19To1_19_1.java
@@ -103,7 +103,7 @@ public final class Protocol1_19To1_19_1 extends BackwardsProtocol<ClientboundPac
                     chatTypeStorage.clear();
 
                     final CompoundTag registry = wrapper.get(Type.NAMED_COMPOUND_TAG, 0);
-                    final ListTag<CompoundTag> chatTypes = TagUtil.removeRegistryEntries(registry, "chat_type");
+                    final ListTag<CompoundTag> chatTypes = TagUtil.removeOptionalRegistryEntries(registry, "chat_type");
                     for (final CompoundTag chatType : chatTypes) {
                         final NumberTag idTag = chatType.getNumberTag("id");
                         chatTypeStorage.addChatType(idTag.asInt(), chatType);


### PR DESCRIPTION
Minecraft doesn't need chat_types in those versions and servers can basically just skip them, this happens in ViaBedrock where chat_types are skipped, you can reproduce this by joining with an e.g. 1.8 client on a bedrock server using ViaProxy. Counterpart pull request for util methods: https://github.com/ViaVersion/ViaVersion/pull/3819