### PR TITLE
Implement handleTranslate() for tags in TranslatableRewriter

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/api/rewriters/TranslatableRewriter.java
+++ b/common/src/main/java/com/viaversion/viabackwards/api/rewriters/TranslatableRewriter.java
@@ -20,9 +20,12 @@ package com.viaversion.viabackwards.api.rewriters;
 import com.viaversion.viabackwards.ViaBackwards;
 import com.viaversion.viabackwards.api.BackwardsProtocol;
 import com.viaversion.viabackwards.api.data.BackwardsMappingDataLoader;
+import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.protocol.packet.ClientboundPacketType;
 import com.viaversion.viaversion.libs.gson.JsonElement;
 import com.viaversion.viaversion.libs.gson.JsonObject;
+import com.viaversion.viaversion.libs.opennbt.tag.builtin.CompoundTag;
+import com.viaversion.viaversion.libs.opennbt.tag.builtin.StringTag;
 import com.viaversion.viaversion.rewriter.ComponentRewriter;
 import java.util.HashMap;
 import java.util.Map;
@@ -64,6 +67,14 @@ public class TranslatableRewriter<C extends ClientboundPacketType> extends Compo
         final String newTranslate = mappedTranslationKey(translate);
         if (newTranslate != null) {
             root.addProperty("translate", newTranslate);
+        }
+    }
+
+    @Override
+    protected void handleTranslate(final UserConnection connection, final CompoundTag parentTag, final StringTag translateTag) {
+        final String newTranslate = mappedTranslationKey(translateTag.getValue());
+        if (newTranslate != null) {
+            parentTag.put("translate", new StringTag(newTranslate));
         }
     }
 


### PR DESCRIPTION
Required in newer protocols (1.20.3->1.20.5) since MC started to use tags instead of jsons for components.

Before (1.20.3 client on 1.20.5 server):
![image](https://github.com/ViaVersion/ViaBackwards/assets/60033407/f01ac74e-fd67-4634-a24d-cae25011b693)

After (same setup):
![image](https://github.com/ViaVersion/ViaBackwards/assets/60033407/dbd11138-ca17-40e7-a9cc-be38cc128d6c)
