### PR TITLE
Fix item mappings with explicit data (0)

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/api/rewriters/LegacyBlockItemRewriter.java
+++ b/common/src/main/java/com/viaversion/viabackwards/api/rewriters/LegacyBlockItemRewriter.java
@@ -93,7 +93,7 @@ public abstract class LegacyBlockItemRewriter<C extends ClientboundPacketType, S
     private void addMapping(String key, JsonObject object, MappedLegacyBlockItem.Type type, Int2ObjectMap<MappedLegacyBlockItem> mappings) {
         int id = object.getAsJsonPrimitive("id").getAsInt();
         JsonPrimitive jsonData = object.getAsJsonPrimitive("data");
-        short data = jsonData != null ? jsonData.getAsShort() : -1;
+        short data = jsonData != null ? jsonData.getAsShort() : 0;
         String name = type != MappedLegacyBlockItem.Type.BLOCK ? object.getAsJsonPrimitive("name").getAsString() : null;
 
         if (key.indexOf('-') == -1) {
@@ -105,7 +105,7 @@ public abstract class LegacyBlockItemRewriter<C extends ClientboundPacketType, S
                 unmappedId = Integer.parseInt(key.substring(0, dataSeparatorIndex));
                 unmappedId = IdAndData.toRawData(unmappedId, unmappedData);
             } else {
-                unmappedId = IdAndData.toRawData(Integer.parseInt(key));
+                unmappedId = IdAndData.toRawData(Integer.parseInt(key), -1);
             }
 
             mappings.put(unmappedId, new MappedLegacyBlockItem(id, data, name, type));

--- a/common/src/main/java/com/viaversion/viabackwards/api/rewriters/LegacyBlockItemRewriter.java
+++ b/common/src/main/java/com/viaversion/viabackwards/api/rewriters/LegacyBlockItemRewriter.java
@@ -361,12 +361,12 @@ public abstract class LegacyBlockItemRewriter<C extends ClientboundPacketType, S
 
     private @Nullable MappedLegacyBlockItem getMappedBlock(int id, int data) {
         MappedLegacyBlockItem mapping = blockReplacements.get(IdAndData.toRawData(id, data));
-        return mapping != null || data == 0 ? mapping : blockReplacements.get(IdAndData.toRawData(id, -1));
+        return mapping != null ? mapping : blockReplacements.get(IdAndData.toRawData(id, -1));
     }
 
     private @Nullable MappedLegacyBlockItem getMappedItem(int id, int data) {
         MappedLegacyBlockItem mapping = itemReplacements.get(IdAndData.toRawData(id, data));
-        return mapping != null || data == 0 ? mapping : itemReplacements.get(IdAndData.toRawData(id, -1));
+        return mapping != null ? mapping : itemReplacements.get(IdAndData.toRawData(id, -1));
     }
 
     private @Nullable MappedLegacyBlockItem getMappedBlock(int rawId) {

--- a/common/src/main/java/com/viaversion/viabackwards/api/rewriters/LegacyBlockItemRewriter.java
+++ b/common/src/main/java/com/viaversion/viabackwards/api/rewriters/LegacyBlockItemRewriter.java
@@ -93,7 +93,7 @@ public abstract class LegacyBlockItemRewriter<C extends ClientboundPacketType, S
     private void addMapping(String key, JsonObject object, MappedLegacyBlockItem.Type type, Int2ObjectMap<MappedLegacyBlockItem> mappings) {
         int id = object.getAsJsonPrimitive("id").getAsInt();
         JsonPrimitive jsonData = object.getAsJsonPrimitive("data");
-        short data = jsonData != null ? jsonData.getAsShort() : 0;
+        short data = jsonData != null ? jsonData.getAsShort() : -1;
         String name = type != MappedLegacyBlockItem.Type.BLOCK ? object.getAsJsonPrimitive("name").getAsString() : null;
 
         if (key.indexOf('-') == -1) {
@@ -361,17 +361,18 @@ public abstract class LegacyBlockItemRewriter<C extends ClientboundPacketType, S
 
     private @Nullable MappedLegacyBlockItem getMappedBlock(int id, int data) {
         MappedLegacyBlockItem mapping = blockReplacements.get(IdAndData.toRawData(id, data));
-        return mapping != null || data == 0 ? mapping : blockReplacements.get(IdAndData.toRawData(id));
+        return mapping != null || data == 0 ? mapping : blockReplacements.get(IdAndData.toRawData(id, -1));
     }
 
     private @Nullable MappedLegacyBlockItem getMappedItem(int id, int data) {
         MappedLegacyBlockItem mapping = itemReplacements.get(IdAndData.toRawData(id, data));
-        return mapping != null || data == 0 ? mapping : itemReplacements.get(IdAndData.toRawData(id));
+        return mapping != null || data == 0 ? mapping : itemReplacements.get(IdAndData.toRawData(id, -1));
     }
 
     private @Nullable MappedLegacyBlockItem getMappedBlock(int rawId) {
-        MappedLegacyBlockItem mapping = blockReplacements.get(rawId);
-        return mapping != null ? mapping : blockReplacements.get(IdAndData.removeData(rawId));
+        int id = IdAndData.getId(rawId);
+        int data = IdAndData.getData(rawId);
+        return getMappedBlock(id, data);
     }
 
     protected JsonObject readMappingsFile(final String name) {

--- a/common/src/main/java/com/viaversion/viabackwards/api/rewriters/LegacyBlockItemRewriter.java
+++ b/common/src/main/java/com/viaversion/viabackwards/api/rewriters/LegacyBlockItemRewriter.java
@@ -120,12 +120,12 @@ public abstract class LegacyBlockItemRewriter<C extends ClientboundPacketType, S
         // Special block color handling
         if (name != null && name.contains("%color%")) {
             for (int i = from; i <= to; i++) {
-                mappings.put(IdAndData.toRawData(i), new MappedLegacyBlockItem(id, data, name.replace("%color%", BlockColors.get(i - from)), type));
+                mappings.put(IdAndData.toRawData(i, -1), new MappedLegacyBlockItem(id, data, name.replace("%color%", BlockColors.get(i - from)), type));
             }
         } else {
             MappedLegacyBlockItem mappedBlockItem = new MappedLegacyBlockItem(id, data, name, type);
             for (int i = from; i <= to; i++) {
-                mappings.put(IdAndData.toRawData(i), mappedBlockItem);
+                mappings.put(IdAndData.toRawData(i, -1), mappedBlockItem);
             }
         }
     }


### PR DESCRIPTION
Uses -1 instead of 0 for internal indicating to look up both id-data and id pairs in mapping files. This never mattered because VB doesn't have mappings where the id is explicit defined, but VR has, so we need to support this properly.

Closes https://github.com/ViaVersion/ViaRewind/issues/513

Would appreciate a review.