### PR TITLE
Fix red nether brick name in 1.11->1.10

### DIFF
--- a/common/src/main/resources/assets/viabackwards/data/item-mappings-1.10.json
+++ b/common/src/main/resources/assets/viabackwards/data/item-mappings-1.10.json
@@ -22,7 +22,7 @@
     },
     "215": {
       "id": 112,
-      "name": "1.10 Red Nether Bricks"
+      "name": "1.10 Red Nether Brick"
     },
     "216": {
       "id": 155,


### PR DESCRIPTION
Everything else matches Minecraft's english translation except this