### PR TITLE
Handle bad heightmaps in 1.17->1.16.4

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/packets/BlockItemPackets1_17.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_16_4to1_17/packets/BlockItemPackets1_17.java
@@ -339,6 +339,10 @@ public final class BlockItemPackets1_17 extends BackwardsItemRewriter<Clientboun
 
             CompoundTag heightMaps = chunk.getHeightMap();
             for (Tag heightMapTag : heightMaps.values()) {
+                if (!(heightMapTag instanceof LongArrayTag)) {
+                    continue; // Client can handle bad data
+                }
+
                 LongArrayTag heightMap = (LongArrayTag) heightMapTag;
                 int[] heightMapData = new int[256];
                 int bitsPerEntry = MathUtil.ceilLog2((currentWorldSectionHeight << 4) + 1);


### PR DESCRIPTION
Client checks if a height map with the type long array is in the nbt, therefore it can handle and silently ignore invalid/bad data, so we should also do it. This check is also present in other rewriters.

1.17.0 read code:
<img width="245" alt="image" src="https://github.com/ViaVersion/ViaBackwards/assets/60033407/9fedc1da-eeaa-4f5f-a4b9-d009d6c1a40f">
