### PR TITLE
Cache dimensions without namespace in 1.19->1.18.2

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_18_2to1_19/packets/EntityPackets1_19.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_18_2to1_19/packets/EntityPackets1_19.java
@@ -133,11 +133,11 @@ public final class EntityPackets1_19 extends EntityRewriter<ClientboundPackets1_
                     final ListTag<CompoundTag> dimensions = TagUtil.getRegistryEntries(registry, "dimension_type");
                     boolean found = false;
                     for (final CompoundTag dimension : dimensions) {
-                        final StringTag nameTag = dimension.getStringTag("name");
+                        final String name = Key.stripMinecraftNamespace(dimension.getString("name"));
                         final CompoundTag dimensionData = dimension.getCompoundTag("element");
-                        dimensionRegistryStorage.addDimension(nameTag.getValue(), dimensionData.copy());
+                        dimensionRegistryStorage.addDimension(name, dimensionData.copy());
 
-                        if (!found && Key.stripMinecraftNamespace(nameTag.getValue()).equals(dimensionKey)) {
+                        if (!found && name.equals(dimensionKey)) {
                             wrapper.write(Type.NAMED_COMPOUND_TAG, dimensionData);
                             found = true;
                         }

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_18_2to1_19/storage/DimensionRegistryStorage.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/protocol1_18_2to1_19/storage/DimensionRegistryStorage.java
@@ -24,6 +24,7 @@ import com.viaversion.viaversion.libs.fastutil.ints.Int2ObjectOpenHashMap;
 import com.viaversion.viaversion.libs.opennbt.tag.builtin.CompoundTag;
 import java.util.HashMap;
 import java.util.Map;
+import com.viaversion.viaversion.util.Key;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class DimensionRegistryStorage implements StorableObject {
@@ -32,7 +33,7 @@ public final class DimensionRegistryStorage implements StorableObject {
     private final Int2ObjectMap<CompoundTag> chatTypes = new Int2ObjectOpenHashMap<>();
 
     public @Nullable CompoundTag dimension(final String dimensionKey) {
-        final CompoundTag compoundTag = dimensions.get(dimensionKey);
+        final CompoundTag compoundTag = dimensions.get(Key.stripMinecraftNamespace(dimensionKey));
         return compoundTag != null ? compoundTag.copy() : null;
     }
 


### PR DESCRIPTION
Fixes edge case were the server doesn't use a namespace when sending the RESPAWN packet but used one in JOIN_GAME, EntityRewriter does the same for dimensions.