### PR TITLE
Add config option to suppress emulation warnings

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/ViaBackwardsConfig.java
+++ b/common/src/main/java/com/viaversion/viabackwards/ViaBackwardsConfig.java
@@ -34,6 +34,7 @@ public class ViaBackwardsConfig extends Config implements com.viaversion.viaback
     private boolean alwaysShowOriginalMobName;
     private boolean fix1_13FormattedInventoryTitles;
     private boolean handlePingsAsInvAcknowledgements;
+    private boolean suppressEmulationWarnings;
 
     public ViaBackwardsConfig(File configFile, Logger logger) {
         super(configFile, logger);
@@ -52,6 +53,7 @@ public class ViaBackwardsConfig extends Config implements com.viaversion.viaback
         fix1_13FormattedInventoryTitles = getBoolean("fix-formatted-inventory-titles", true);
         alwaysShowOriginalMobName = getBoolean("always-show-original-mob-name", true);
         handlePingsAsInvAcknowledgements = getBoolean("handle-pings-as-inv-acknowledgements", false);
+        suppressEmulationWarnings = getBoolean("suppress-emulation-warnings", false);
     }
 
     @Override
@@ -82,6 +84,11 @@ public class ViaBackwardsConfig extends Config implements com.viaversion.viaback
     @Override
     public boolean handlePingsAsInvAcknowledgements() {
         return handlePingsAsInvAcknowledgements || Boolean.getBoolean("com.viaversion.handlePingsAsInvAcknowledgements");
+    }
+
+    @Override
+    public boolean suppressEmulationWarnings() {
+        return suppressEmulationWarnings;
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viabackwards/api/ViaBackwardsConfig.java
+++ b/common/src/main/java/com/viaversion/viabackwards/api/ViaBackwardsConfig.java
@@ -63,4 +63,11 @@ public interface ViaBackwardsConfig extends Config {
      * @return true if enabled
      */
     boolean handlePingsAsInvAcknowledgements();
+
+    /**
+     * Suppresses warnings of missing emulations for certain features that are not supported (e.g. world height in 1.17+).
+     *
+     * @return true if enabled
+     */
+    boolean suppressEmulationWarnings();
 }

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_16_2to1_16_1/rewriter/EntityPacketRewriter1_16_2.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_16_2to1_16_1/rewriter/EntityPacketRewriter1_16_2.java
@@ -83,7 +83,7 @@ public class EntityPacketRewriter1_16_2 extends EntityRewriter<ClientboundPacket
                             NumberTag id = biome.getNumberTag("id");
                             biomeStorage.addBiome(name.getValue(), id.asInt());
                         }
-                    } else if (!warned) {
+                    } else if (!warned && !ViaBackwards.getConfig().suppressEmulationWarnings()) {
                         warned = true;
                         protocol.getLogger().warning("1.16 and 1.16.1 clients are only partially supported and may have wrong biomes displayed.");
                     }

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_17to1_16_4/rewriter/EntityPacketRewriter1_17.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_17to1_16_4/rewriter/EntityPacketRewriter1_17.java
@@ -206,7 +206,7 @@ public final class EntityPacketRewriter1_17 extends EntityRewriter<ClientboundPa
         NumberTag height = tag.getNumberTag("height");
         NumberTag logicalHeight = tag.getNumberTag("logical_height");
         if (minY.asInt() != 0 || height.asInt() > 256 || logicalHeight.asInt() > 256) {
-            if (warn && !warned) {
+            if (warn && !warned && !ViaBackwards.getConfig().suppressEmulationWarnings()) {
                 protocol.getLogger().warning("Increased world height is NOT SUPPORTED for 1.16 players and below. They will see a void below y 0 and above 256");
                 warned = true;
             }

--- a/common/src/main/resources/assets/viabackwards/config.yml
+++ b/common/src/main/resources/assets/viabackwards/config.yml
@@ -20,3 +20,6 @@ fix-formatted-inventory-titles: true
 # Sends inventory acknowledgement packets to act as a replacement for ping packets for sub 1.17 clients.
 # This only takes effect for ids in the short range. Useful for anticheat compatibility.
 handle-pings-as-inv-acknowledgements: false
+#
+# Suppresses warnings of missing emulations for certain features that are not supported (e.g. world height in 1.17+).
+suppress-emulation-warnings: false


### PR DESCRIPTION
I decided to move this into an own setting instead of reusing the suppress-conversion-warning setting since a lot of people might already have ViaVersion's setting enabled and people should only disable warnings such the world height one if they really understand that the feature isn't supported.