### PR TITLE
Redesign TranslatableRewriter to be usable in other projects as well

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/api/rewriters/TranslatableRewriter.java
+++ b/common/src/main/java/com/viaversion/viabackwards/api/rewriters/TranslatableRewriter.java
@@ -17,7 +17,6 @@
  */
 package com.viaversion.viabackwards.api.rewriters;
 
-import com.viaversion.viabackwards.ViaBackwards;
 import com.viaversion.viabackwards.api.BackwardsProtocol;
 import com.viaversion.viabackwards.api.data.BackwardsMappingDataLoader;
 import com.viaversion.viaversion.api.connection.UserConnection;
@@ -37,10 +36,16 @@ public class TranslatableRewriter<C extends ClientboundPacketType> extends Compo
     private final Map<String, String> translatables;
 
     public static void loadTranslatables() {
-        final JsonObject jsonObject = BackwardsMappingDataLoader.INSTANCE.loadFromDataDir("translation-mappings.json");
+        if (!TRANSLATABLES.isEmpty()) {
+            throw new IllegalStateException("Translatables already loaded!");
+        }
+        fillTranslatables(BackwardsMappingDataLoader.INSTANCE.loadFromDataDir("translation-mappings.json"), TRANSLATABLES);
+    }
+
+    public static void fillTranslatables(final JsonObject jsonObject, final Map<String, Map<String, String>> translatables) {
         for (final Map.Entry<String, JsonElement> entry : jsonObject.entrySet()) {
             final Map<String, String> versionMappings = new HashMap<>();
-            TRANSLATABLES.put(entry.getKey(), versionMappings);
+            translatables.put(entry.getKey(), versionMappings);
             for (final Map.Entry<String, JsonElement> translationEntry : entry.getValue().getAsJsonObject().entrySet()) {
                 versionMappings.put(translationEntry.getKey(), translationEntry.getValue().getAsString());
             }
@@ -53,7 +58,7 @@ public class TranslatableRewriter<C extends ClientboundPacketType> extends Compo
 
     public TranslatableRewriter(final BackwardsProtocol<C, ?, ?, ?> protocol, final ReadType type, final String sectionIdentifier) {
         super(protocol, type);
-        final Map<String, String> translatableMappings = TRANSLATABLES.get(sectionIdentifier);
+        final Map<String, String> translatableMappings = getTranslatableMappings(sectionIdentifier);
         if (translatableMappings == null) {
             protocol.getLogger().warning("Missing " + sectionIdentifier + " translatables!");
             this.translatables = new HashMap<>();
@@ -80,5 +85,9 @@ public class TranslatableRewriter<C extends ClientboundPacketType> extends Compo
 
     public @Nullable String mappedTranslationKey(final String translationKey) {
         return translatables.get(translationKey);
+    }
+
+    public Map<String, String> getTranslatableMappings(final String sectionIdentifier) {
+        return TRANSLATABLES.get(sectionIdentifier);
     }
 }


### PR DESCRIPTION
Makes the rewriter to be actual API which can be used in ViaRewind later on.