### PR TITLE
Handle block state particles when identifier is used in 1.20.5->.3

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_20_5to1_20_3/rewriter/EntityPacketRewriter1_20_5.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_20_5to1_20_3/rewriter/EntityPacketRewriter1_20_5.java
@@ -283,8 +283,13 @@ public final class EntityPacketRewriter1_20_5 extends EntityRewriter<Clientbound
 
     private void updateParticleFormat(final CompoundTag options, final String particleType) {
         if ("block".equals(particleType) || "block_marker".equals(particleType) || "falling_dust".equals(particleType) || "dust_pillar".equals(particleType)) {
-            // TODO Can be a string
-            moveTag(options, "block_state", "value");
+            Tag blockState = options.remove("block_state");
+            if (blockState instanceof StringTag) {
+                final CompoundTag compoundTag = new CompoundTag();
+                compoundTag.put("Name", blockState);
+                blockState = compoundTag;
+            }
+            options.put("value", blockState);
         } else if ("item".equals(particleType)) {
             Tag item = options.remove("item");
             if (item instanceof StringTag) {


### PR DESCRIPTION
Resolves TODO, didn't test in game, but the format looks the same when printing it out using NbtOps and a Fabric 1.20.4/1.20.6 mod (Edit; should use the pr title when merging because I mixed up versions in my commit msg)