### PR TITLE
[ci skip] Replace GitHub link to hangar/viaversion.com sub link

### DIFF
--- a/build-logic/src/main/kotlin/vb.base-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/vb.base-conventions.gradle.kts
@@ -7,7 +7,7 @@ tasks {
     // Variable replacements
     processResources {
         filesMatching(listOf("plugin.yml", "META-INF/sponge_plugins.json", "fabric.mod.json", "bungee.yml")) {
-            expand("version" to project.version, "description" to project.description, "url" to "https://github.com/ViaVersion/ViaBackwards")
+            expand("version" to project.version, "description" to project.description, "url" to "https://viaversion.com/backwards")
         }
     }
     javadoc {


### PR DESCRIPTION
Matches ViaRewind's bukkit.yml