### PR TITLE
Handle 1.14->1.13.2 lore tag properly

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_14to1_13_2/rewriter/BlockItemPacketRewriter1_14.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_14to1_13_2/rewriter/BlockItemPacketRewriter1_14.java
@@ -468,9 +468,9 @@ public class BlockItemPacketRewriter1_14 extends BackwardsItemRewriter<Clientbou
             if (lore != null) {
                 saveListTag(display, lore, "Lore");
 
-                final Iterator<StringTag> each = lore.iterator();
-                while (each.hasNext()) {
-                    try {
+                try {
+                    final Iterator<StringTag> each = lore.iterator();
+                    while (each.hasNext()) {
                         final StringTag loreEntry = each.next();
                         final var component = SerializerVersion.V1_12.toComponent(loreEntry.getValue());
                         if (component == null) {
@@ -478,10 +478,9 @@ public class BlockItemPacketRewriter1_14 extends BackwardsItemRewriter<Clientbou
                             continue;
                         }
                         loreEntry.setValue(component.asLegacyFormatString());
-                    } catch (final JsonParseException e) {
-                        display.remove("Lore");
-                        break;
                     }
+                } catch (final JsonParseException e) {
+                    display.remove("Lore");
                 }
             }
         }

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_14to1_13_2/rewriter/BlockItemPacketRewriter1_14.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_14to1_13_2/rewriter/BlockItemPacketRewriter1_14.java
@@ -18,7 +18,6 @@
 package com.viaversion.viabackwards.protocol.v1_14to1_13_2.rewriter;
 
 import com.google.common.collect.ImmutableSet;
-import com.viaversion.viabackwards.ViaBackwards;
 import com.viaversion.viabackwards.api.rewriters.BackwardsItemRewriter;
 import com.viaversion.viabackwards.api.rewriters.EnchantmentRewriter;
 import com.viaversion.viabackwards.protocol.v1_14to1_13_2.Protocol1_14To1_13_2;
@@ -38,7 +37,6 @@ import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_14;
 import com.viaversion.viaversion.api.minecraft.item.Item;
 import com.viaversion.viaversion.api.minecraft.entitydata.EntityData;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
-import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.chunk.ChunkType1_13;
 import com.viaversion.viaversion.api.type.types.chunk.ChunkType1_14;
@@ -49,6 +47,7 @@ import com.viaversion.viaversion.libs.gson.JsonObject;
 import com.viaversion.nbt.tag.CompoundTag;
 import com.viaversion.nbt.tag.ListTag;
 import com.viaversion.nbt.tag.StringTag;
+import com.viaversion.viaversion.libs.gson.JsonParseException;
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.packet.ClientboundPackets1_13;
 import com.viaversion.viaversion.protocols.v1_12_2to1_13.packet.ServerboundPackets1_13;
 import com.viaversion.viaversion.protocols.v1_13_2to1_14.Protocol1_13_2To1_14;
@@ -57,7 +56,9 @@ import com.viaversion.viaversion.rewriter.BlockRewriter;
 import com.viaversion.viaversion.rewriter.RecipeRewriter;
 import com.viaversion.viaversion.util.ComponentUtil;
 import com.viaversion.viaversion.util.Key;
+import com.viaversion.viaversion.util.SerializerVersion;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -467,10 +468,19 @@ public class BlockItemPacketRewriter1_14 extends BackwardsItemRewriter<Clientbou
             if (lore != null) {
                 saveListTag(display, lore, "Lore");
 
-                for (StringTag loreEntry : lore) {
-                    String value = loreEntry.getValue();
-                    if (value != null && !value.isEmpty()) {
-                        loreEntry.setValue(ComponentUtil.jsonToLegacy(value));
+                final Iterator<StringTag> each = lore.iterator();
+                while (each.hasNext()) {
+                    try {
+                        final StringTag loreEntry = each.next();
+                        final var component = SerializerVersion.V1_12.toComponent(loreEntry.getValue());
+                        if (component == null) {
+                            each.remove();
+                            continue;
+                        }
+                        loreEntry.setValue(component.asLegacyFormatString());
+                    } catch (final JsonParseException e) {
+                        display.remove("Lore");
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
Handle the lore tag like 1.14 does by checking for null components / removing the entire lore tag when one of its entries is invalid; I believe we would also need this for name conversion one protocol below. The Problem is that we need to handle translations there, and since the current component rewriter base relies on JsonElement, we would need to parse the name multiple times, so I left this out.

1.14 source code:
<img width="545" alt="image" src="https://github.com/ViaVersion/ViaBackwards/assets/60033407/09d1f07e-ab68-487e-a623-062b81865890">

