### PR TITLE
Send registry data before finish configuration in 1.20.5->1.20.3

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_20_5to1_20_3/Protocol1_20_5To1_20_3.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_20_5to1_20_3/Protocol1_20_5To1_20_3.java
@@ -78,16 +78,16 @@ public final class Protocol1_20_5To1_20_3 extends BackwardsProtocol<ClientboundP
         super.registerPackets();
 
         tagRewriter.registerGeneric(ClientboundPackets1_20_5.UPDATE_TAGS);
-        registerClientbound(ClientboundConfigurationPackets1_20_5.UPDATE_TAGS, wrapper -> {
+        registerClientbound(ClientboundConfigurationPackets1_20_5.UPDATE_TAGS, wrapper -> tagRewriter.getGenericHandler().handle(wrapper));
+
+        registerClientbound(ClientboundPackets1_20_5.START_CONFIGURATION, wrapper -> wrapper.user().get(RegistryDataStorage.class).clear());
+
+        registerClientbound(ClientboundConfigurationPackets1_20_5.FINISH_CONFIGURATION, wrapper -> {
             // Send off registry data first
             final PacketWrapper registryDataPacket = wrapper.create(ClientboundConfigurationPackets1_20_3.REGISTRY_DATA);
             registryDataPacket.write(Types.COMPOUND_TAG, wrapper.user().get(RegistryDataStorage.class).registryData().copy());
             registryDataPacket.send(Protocol1_20_5To1_20_3.class);
-
-            tagRewriter.getGenericHandler().handle(wrapper);
         });
-
-        registerClientbound(ClientboundPackets1_20_5.START_CONFIGURATION, wrapper -> wrapper.user().get(RegistryDataStorage.class).clear());
 
         final SoundRewriter<ClientboundPacket1_20_5> soundRewriter = new SoundRewriter<>(this);
         soundRewriter.registerSound1_19_3(ClientboundPackets1_20_5.SOUND);

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_20_5to1_20_3/Protocol1_20_5To1_20_3.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_20_5to1_20_3/Protocol1_20_5To1_20_3.java
@@ -78,7 +78,7 @@ public final class Protocol1_20_5To1_20_3 extends BackwardsProtocol<ClientboundP
         super.registerPackets();
 
         tagRewriter.registerGeneric(ClientboundPackets1_20_5.UPDATE_TAGS);
-        registerClientbound(ClientboundConfigurationPackets1_20_5.UPDATE_TAGS, wrapper -> tagRewriter.getGenericHandler().handle(wrapper));
+        tagRewriter.registerGeneric(ClientboundConfigurationPackets1_20_5.UPDATE_TAGS);
 
         registerClientbound(ClientboundPackets1_20_5.START_CONFIGURATION, wrapper -> wrapper.user().get(RegistryDataStorage.class).clear());
 


### PR DESCRIPTION
We can't rely on UPDATE_TAGS since the server could send it before sending registry data (or not sending it at all in config state), so we need to choose the last packet before PLAY state to send registry data.

Closes https://github.com/ViaVersion/ViaBackwards/issues/777