### PR TITLE
Write player rotation on USE_ITEM in 1.21->1.20.5

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21to1_20_5/Protocol1_21To1_20_5.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21to1_20_5/Protocol1_21To1_20_5.java
@@ -25,6 +25,7 @@ import com.viaversion.viabackwards.protocol.v1_21to1_20_5.rewriter.BlockItemPack
 import com.viaversion.viabackwards.protocol.v1_21to1_20_5.rewriter.ComponentRewriter1_21;
 import com.viaversion.viabackwards.protocol.v1_21to1_20_5.rewriter.EntityPacketRewriter1_21;
 import com.viaversion.viabackwards.protocol.v1_21to1_20_5.storage.EnchantmentsPaintingsStorage;
+import com.viaversion.viabackwards.protocol.v1_21to1_20_5.storage.PlayerRotationStorage;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.minecraft.Holder;
 import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_20_5;
@@ -186,6 +187,7 @@ public final class Protocol1_21To1_20_5 extends BackwardsProtocol<ClientboundPac
     public void init(final UserConnection user) {
         addEntityTracker(user, new EntityTrackerBase(user, EntityTypes1_20_5.PLAYER));
         user.put(new EnchantmentsPaintingsStorage());
+        user.put(new PlayerRotationStorage());
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21to1_20_5/rewriter/BlockItemPacketRewriter1_21.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21to1_20_5/rewriter/BlockItemPacketRewriter1_21.java
@@ -26,6 +26,7 @@ import com.viaversion.viabackwards.api.rewriters.EnchantmentRewriter;
 import com.viaversion.viabackwards.api.rewriters.StructuredEnchantmentRewriter;
 import com.viaversion.viabackwards.protocol.v1_21to1_20_5.Protocol1_21To1_20_5;
 import com.viaversion.viabackwards.protocol.v1_21to1_20_5.storage.EnchantmentsPaintingsStorage;
+import com.viaversion.viabackwards.protocol.v1_21to1_20_5.storage.PlayerRotationStorage;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.minecraft.data.StructuredData;
 import com.viaversion.viaversion.api.minecraft.data.StructuredDataContainer;
@@ -111,8 +112,10 @@ public final class BlockItemPacketRewriter1_21 extends BackwardsStructuredItemRe
         protocol.registerServerbound(ServerboundPackets1_20_5.USE_ITEM, wrapper -> {
             wrapper.passthrough(Types.VAR_INT); // Hand
             wrapper.passthrough(Types.VAR_INT); // Sequence
-            wrapper.write(Types.FLOAT, 0f); // Y rotation
-            wrapper.write(Types.FLOAT, 0f); // X rotation
+
+            final PlayerRotationStorage rotation = wrapper.user().get(PlayerRotationStorage.class);
+            wrapper.write(Types.FLOAT, rotation.yaw()); // Y rotation
+            wrapper.write(Types.FLOAT, rotation.pitch()); // X rotation
         });
 
         new RecipeRewriter1_20_3<>(protocol).register1_20_5(ClientboundPackets1_21.UPDATE_RECIPES);

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21to1_20_5/storage/PlayerRotationStorage.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21to1_20_5/storage/PlayerRotationStorage.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of ViaBackwards - https://github.com/ViaVersion/ViaBackwards
+ * Copyright (C) 2016-2024 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viabackwards.protocol.v1_21to1_20_5.storage;
+
+import com.viaversion.viaversion.api.connection.StorableObject;
+
+public final class PlayerRotationStorage implements StorableObject {
+
+    private float yaw, pitch;
+
+    public void setRotation(final float yaw, final float pitch) {
+        this.yaw = yaw;
+        this.pitch = pitch;
+    }
+
+    public float yaw() {
+        return yaw;
+    }
+
+    public float pitch() {
+        return pitch;
+    }
+}


### PR DESCRIPTION
Just inserting zero will result in some items not being usable as a client; we need correct values here.

Can be tested by trying to place a water bucket.