### PR TITLE
Remove ViaRewind recommendation in fabric.mod.json

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -29,9 +29,6 @@
     "fabricloader": ">=0.14.0",
     "viafabric": ">=0.4.10"
   },
-  "recommends": {
-    "viarewind": "*"
-  },
     "custom": {
         "modmenu:api": true,
         "modmenu": {


### PR DESCRIPTION
Confused people in the past in support channels / on other discord servers installing VR even though they didn't need it.
(And I think barely anyone uses ViaFabric 1.8/1.12)