### PR TITLE
Put enchantment level into translatables in enchantment rewriters

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/api/rewriters/EnchantmentRewriter.java
+++ b/common/src/main/java/com/viaversion/viabackwards/api/rewriters/EnchantmentRewriter.java
@@ -157,7 +157,7 @@ public class EnchantmentRewriter {
             case 8 -> "VIII";
             case 9 -> "IX";
             case 10 -> "X";
-            default -> Integer.toString(number);
+            default -> "enchantment.level." + number;
         };
     }
 }

--- a/common/src/main/java/com/viaversion/viabackwards/api/rewriters/EnchantmentRewriter.java
+++ b/common/src/main/java/com/viaversion/viabackwards/api/rewriters/EnchantmentRewriter.java
@@ -17,12 +17,12 @@
  */
 package com.viaversion.viabackwards.api.rewriters;
 
+import com.viaversion.viabackwards.utils.ChatUtil;
 import com.viaversion.viaversion.api.minecraft.item.Item;
 import com.viaversion.nbt.tag.CompoundTag;
 import com.viaversion.nbt.tag.ListTag;
 import com.viaversion.nbt.tag.NumberTag;
 import com.viaversion.nbt.tag.StringTag;
-import com.viaversion.viaversion.util.ComponentUtil;
 import com.viaversion.viaversion.util.Key;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -34,6 +34,8 @@ import java.util.Map;
  * Rewriter to handle the addition of new enchantments.
  */
 public class EnchantmentRewriter {
+
+    public static final String ENCHANTMENT_LEVEL_TRANSLATION = "enchantment.level.%s";
 
     protected final Map<String, String> enchantmentMappings = new HashMap<>();
     protected final BackwardsItemRewriter<?, ?, ?> itemRewriter;
@@ -103,9 +105,11 @@ public class EnchantmentRewriter {
 
                 NumberTag levelTag = enchantmentEntry.getNumberTag("lvl");
                 int level = levelTag != null ? levelTag.asInt() : 1;
-                String loreValue = remappedName + " " + getRomanNumber(level);
+                String loreValue;
                 if (jsonFormat) {
-                    loreValue = ComponentUtil.legacyToJsonString(loreValue);
+                    loreValue = ChatUtil.legacyToJsonString(remappedName, ENCHANTMENT_LEVEL_TRANSLATION.formatted(level), true);
+                } else {
+                    loreValue = remappedName + " " + getRomanNumber(level);
                 }
 
                 loreToAdd.add(new StringTag(loreValue));
@@ -157,7 +161,7 @@ public class EnchantmentRewriter {
             case 8 -> "VIII";
             case 9 -> "IX";
             case 10 -> "X";
-            default -> "enchantment.level." + number;
+            default -> ENCHANTMENT_LEVEL_TRANSLATION.formatted(number); // Fallback to translation to match vanilla style
         };
     }
 }

--- a/common/src/main/java/com/viaversion/viabackwards/api/rewriters/StructuredEnchantmentRewriter.java
+++ b/common/src/main/java/com/viaversion/viabackwards/api/rewriters/StructuredEnchantmentRewriter.java
@@ -23,6 +23,7 @@ import com.viaversion.nbt.tag.ListTag;
 import com.viaversion.nbt.tag.NumberTag;
 import com.viaversion.nbt.tag.Tag;
 import com.viaversion.viabackwards.api.data.BackwardsMappingData;
+import com.viaversion.viabackwards.utils.ChatUtil;
 import com.viaversion.viaversion.api.data.Mappings;
 import com.viaversion.viaversion.api.minecraft.data.StructuredData;
 import com.viaversion.viaversion.api.minecraft.data.StructuredDataContainer;
@@ -36,6 +37,8 @@ import com.viaversion.viaversion.util.ComponentUtil;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import static com.viaversion.viabackwards.api.rewriters.EnchantmentRewriter.ENCHANTMENT_LEVEL_TRANSLATION;
 
 public class StructuredEnchantmentRewriter {
 
@@ -55,7 +58,7 @@ public class StructuredEnchantmentRewriter {
         };
         final DescriptionSupplier descriptionSupplier = (id, level) -> {
             final String remappedName = mappingData.mappedEnchantmentName(id);
-            return ComponentUtil.jsonStringToTag(ComponentUtil.legacyToJsonString("§7" + remappedName + " " + EnchantmentRewriter.getRomanNumber(level), true));
+            return ComponentUtil.jsonStringToTag(ChatUtil.legacyToJsonString("§7" + remappedName, ENCHANTMENT_LEVEL_TRANSLATION.formatted(level), true));
         };
         rewriteEnchantmentsToClient(data, StructuredDataKey.ENCHANTMENTS, idRewriteFunction, descriptionSupplier, false);
         rewriteEnchantmentsToClient(data, StructuredDataKey.STORED_ENCHANTMENTS, idRewriteFunction, descriptionSupplier, true);

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21to1_20_5/rewriter/BlockItemPacketRewriter1_21.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21to1_20_5/rewriter/BlockItemPacketRewriter1_21.java
@@ -53,6 +53,8 @@ import java.util.List;
 import static com.viaversion.viaversion.protocols.v1_20_5to1_21.rewriter.BlockItemPacketRewriter1_21.downgradeItemData;
 import static com.viaversion.viaversion.protocols.v1_20_5to1_21.rewriter.BlockItemPacketRewriter1_21.updateItemData;
 
+import static com.viaversion.viabackwards.api.rewriters.EnchantmentRewriter.ENCHANTMENT_LEVEL_TRANSLATION;
+
 public final class BlockItemPacketRewriter1_21 extends BackwardsStructuredItemRewriter<ClientboundPacket1_21, ServerboundPacket1_20_5, Protocol1_21To1_20_5> {
 
     private final StructuredEnchantmentRewriter enchantmentRewriter = new StructuredEnchantmentRewriter(this);
@@ -144,8 +146,8 @@ public final class BlockItemPacketRewriter1_21 extends BackwardsStructuredItemRe
             }
 
             final CompoundTag fullDescription = new CompoundTag();
-            fullDescription.putString("translate", "%s " + EnchantmentRewriter.getRomanNumber(level));
-            fullDescription.put("with", new ListTag<>(Arrays.asList(description)));
+            fullDescription.putString("translate", "%s %s");
+            fullDescription.put("with", new ListTag<>(Arrays.asList(description, new StringTag(ENCHANTMENT_LEVEL_TRANSLATION.formatted(level)))));
             return fullDescription;
         };
         enchantmentRewriter.rewriteEnchantmentsToClient(data, StructuredDataKey.ENCHANTMENTS, idRewriteFunction, descriptionSupplier, false);

--- a/common/src/main/java/com/viaversion/viabackwards/utils/ChatUtil.java
+++ b/common/src/main/java/com/viaversion/viabackwards/utils/ChatUtil.java
@@ -17,9 +17,15 @@
  */
 package com.viaversion.viabackwards.utils;
 
+import com.viaversion.viaversion.libs.mcstructs.text.ATextComponent;
+import com.viaversion.viaversion.libs.mcstructs.text.Style;
+import com.viaversion.viaversion.libs.mcstructs.text.components.TranslationComponent;
+import com.viaversion.viaversion.libs.mcstructs.text.serializer.LegacyStringDeserializer;
+import com.viaversion.viaversion.util.SerializerVersion;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
 public final class ChatUtil {
@@ -28,6 +34,23 @@ public final class ChatUtil {
 
     public static String removeUnusedColor(String legacy, char defaultColor) {
         return removeUnusedColor(legacy, defaultColor, false);
+    }
+
+    public static String legacyToJsonString(String legacy, String translation, boolean itemData) {
+        return legacyToJsonString(legacy, text -> {
+            text.append(" ");
+            text.append(new TranslationComponent(translation));
+        }, itemData);
+    }
+
+    public static String legacyToJsonString(String legacy, Consumer<ATextComponent> consumer, boolean itemData) {
+        final ATextComponent component = LegacyStringDeserializer.parse(legacy, true);
+        consumer.accept(component);
+
+        if (itemData) {
+            component.setParentStyle((new Style()).setItalic(false));
+        }
+        return SerializerVersion.V1_12.toString(component);
     }
 
     private static class ChatFormattingState {


### PR DESCRIPTION
MC 1.8-1.21 uses translation keys for every enchantment level meaning an invalid level would default to the translation key (`enchantment.level.<level>`) and not the uncovered level.

![image](https://github.com/ViaVersion/ViaBackwards/assets/60033407/8ebf3f9f-ef71-4334-a693-1729ca81905a)
![image](https://github.com/ViaVersion/ViaBackwards/assets/60033407/a0a05d3a-2fca-4698-9020-996adfb163c8)
