### PR TITLE
Fix possible BannerHandler NPE in 1.13->1.12.2

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_13to1_12_2/block_entity_handlers/BannerHandler.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_13to1_12_2/block_entity_handlers/BannerHandler.java
@@ -51,7 +51,9 @@ public class BannerHandler implements BackwardsBlockEntityHandler {
         if (patternsTag != null) {
             for (CompoundTag pattern : patternsTag) {
                 NumberTag colorTag = pattern.getNumberTag("Color");
-                pattern.putInt("Color", 15 - colorTag.asInt()); // Invert color id
+                if (colorTag != null) {
+                    pattern.putInt("Color", 15 - colorTag.asInt()); // Invert color id
+                }
             }
         }
 


### PR DESCRIPTION
Minecraft won't throw an error because their NBT library fallbacks to 0 when an integer isn't present (checked in both versions). Fixes an issue from our discord.