### PR TITLE
Include new bedrock-at-0 config option in world height warning

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_17to1_16_4/rewriter/EntityPacketRewriter1_17.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_17to1_16_4/rewriter/EntityPacketRewriter1_17.java
@@ -35,7 +35,7 @@ import com.viaversion.viaversion.util.TagUtil;
 
 public final class EntityPacketRewriter1_17 extends EntityRewriter<ClientboundPackets1_17, Protocol1_17To1_16_4> {
 
-    private boolean warned = ViaBackwards.getConfig().bedrockAtY0();
+    private boolean warned = ViaBackwards.getConfig().bedrockAtY0() || ViaBackwards.getConfig().suppressEmulationWarnings();
 
     public EntityPacketRewriter1_17(Protocol1_17To1_16_4 protocol) {
         super(protocol);
@@ -210,7 +210,7 @@ public final class EntityPacketRewriter1_17 extends EntityRewriter<ClientboundPa
         NumberTag height = tag.getNumberTag("height");
         NumberTag logicalHeight = tag.getNumberTag("logical_height");
         if (minY.asInt() != 0 || height.asInt() > 256 || logicalHeight.asInt() > 256) {
-            if (warn && !warned && !ViaBackwards.getConfig().suppressEmulationWarnings()) {
+            if (warn && !warned) {
                 protocol.getLogger().warning("Increased world height is NOT SUPPORTED for 1.16 players and below. They will see a void below y 0 and above 256. You can enable the `bedrock-at-y-0` config option to replace the air with a bedrock layer.");
                 warned = true;
             }

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_17to1_16_4/rewriter/EntityPacketRewriter1_17.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_17to1_16_4/rewriter/EntityPacketRewriter1_17.java
@@ -35,7 +35,7 @@ import com.viaversion.viaversion.util.TagUtil;
 
 public final class EntityPacketRewriter1_17 extends EntityRewriter<ClientboundPackets1_17, Protocol1_17To1_16_4> {
 
-    private boolean warned;
+    private boolean warned = ViaBackwards.getConfig().bedrockAtY0();
 
     public EntityPacketRewriter1_17(Protocol1_17To1_16_4 protocol) {
         super(protocol);
@@ -211,7 +211,7 @@ public final class EntityPacketRewriter1_17 extends EntityRewriter<ClientboundPa
         NumberTag logicalHeight = tag.getNumberTag("logical_height");
         if (minY.asInt() != 0 || height.asInt() > 256 || logicalHeight.asInt() > 256) {
             if (warn && !warned && !ViaBackwards.getConfig().suppressEmulationWarnings()) {
-                protocol.getLogger().warning("Increased world height is NOT SUPPORTED for 1.16 players and below. They will see a void below y 0 and above 256");
+                protocol.getLogger().warning("Increased world height is NOT SUPPORTED for 1.16 players and below. They will see a void below y 0 and above 256. You can enable the `bedrock-at-y-0` config option to replace the air with a bedrock layer.");
                 warned = true;
             }
 


### PR DESCRIPTION
No need to print the warning when the user has already enabled the workaround since he should be aware of the behaviour, also mention the new option so people know about it.