### PR TITLE
Add alternative sculk shrieker mapping in 1.19->1.18.2

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/ViaBackwardsConfig.java
+++ b/common/src/main/java/com/viaversion/viabackwards/ViaBackwardsConfig.java
@@ -35,6 +35,7 @@ public class ViaBackwardsConfig extends Config implements com.viaversion.viaback
     private boolean fix1_13FormattedInventoryTitles;
     private boolean handlePingsAsInvAcknowledgements;
     private boolean bedrockAtY0;
+    private boolean sculkShriekersToCryingObsidian;
     private boolean suppressEmulationWarnings;
 
     public ViaBackwardsConfig(File configFile, Logger logger) {
@@ -55,6 +56,7 @@ public class ViaBackwardsConfig extends Config implements com.viaversion.viaback
         alwaysShowOriginalMobName = getBoolean("always-show-original-mob-name", true);
         handlePingsAsInvAcknowledgements = getBoolean("handle-pings-as-inv-acknowledgements", false);
         bedrockAtY0 = getBoolean("bedrock-at-y-0", false);
+        sculkShriekersToCryingObsidian = getBoolean("sculk-shriekers-to-crying-obsidian", false);
         suppressEmulationWarnings = getBoolean("suppress-emulation-warnings", false);
     }
 
@@ -91,6 +93,11 @@ public class ViaBackwardsConfig extends Config implements com.viaversion.viaback
     @Override
     public boolean bedrockAtY0() {
         return bedrockAtY0;
+    }
+
+    @Override
+    public boolean sculkShriekerToCryingObsidian() {
+        return sculkShriekersToCryingObsidian;
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viabackwards/api/ViaBackwardsConfig.java
+++ b/common/src/main/java/com/viaversion/viabackwards/api/ViaBackwardsConfig.java
@@ -72,6 +72,13 @@ public interface ViaBackwardsConfig extends Config {
     boolean bedrockAtY0();
 
     /**
+     * Shows sculk shriekers as crying obsidian for 1.18.2 clients on 1.19+ servers. This fixes collision and block breaking issues.
+     *
+     * @return true if enabled
+     */
+    boolean sculkShriekerToCryingObsidian();
+
+    /**
      * Suppresses warnings of missing emulations for certain features that are not supported (e.g. world height in 1.17+).
      *
      * @return true if enabled

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_19to1_18_2/data/BackwardsMappingData1_19.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_19to1_18_2/data/BackwardsMappingData1_19.java
@@ -30,6 +30,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class BackwardsMappingData1_19 extends BackwardsMappingData {
 
+    private final boolean sculkShriekerToCryingObsidian = ViaBackwards.getConfig().sculkShriekerToCryingObsidian();
+
     private final Int2ObjectMap<CompoundTag> defaultChatTypes = new Int2ObjectOpenHashMap<>();
 
     public BackwardsMappingData1_19() {
@@ -40,8 +42,7 @@ public final class BackwardsMappingData1_19 extends BackwardsMappingData {
     protected void loadExtras(final CompoundTag data) {
         super.loadExtras(data);
 
-        if (ViaBackwards.getConfig().sculkShriekerToCryingObsidian()) {
-            itemMappings.setNewId(329, 1065);
+        if (sculkShriekerToCryingObsidian) {
             blockMappings.setNewId(850, 750);
             for (int i = 18900; i <= 18907; i++) {
                 blockStateMappings.setNewId(i, 16082);
@@ -53,6 +54,14 @@ public final class BackwardsMappingData1_19 extends BackwardsMappingData {
             final NumberTag idTag = chatType.getNumberTag("id");
             defaultChatTypes.put(idTag.asInt(), chatType);
         }
+    }
+
+    @Override
+    public int getNewItemId(final int id) {
+        if (sculkShriekerToCryingObsidian && id == 329) {
+            return 1065;
+        }
+        return super.getNewItemId(id);
     }
 
     public @Nullable CompoundTag chatType(final int id) {

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_19to1_18_2/data/BackwardsMappingData1_19.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_19to1_18_2/data/BackwardsMappingData1_19.java
@@ -17,6 +17,7 @@
  */
 package com.viaversion.viabackwards.protocol.v1_19to1_18_2.data;
 
+import com.viaversion.viabackwards.ViaBackwards;
 import com.viaversion.viabackwards.api.data.BackwardsMappingData;
 import com.viaversion.viabackwards.api.data.BackwardsMappingDataLoader;
 import com.viaversion.viaversion.libs.fastutil.ints.Int2ObjectMap;
@@ -38,6 +39,14 @@ public final class BackwardsMappingData1_19 extends BackwardsMappingData {
     @Override
     protected void loadExtras(final CompoundTag data) {
         super.loadExtras(data);
+
+        if (ViaBackwards.getConfig().sculkShriekerToCryingObsidian()) {
+            itemMappings.setNewId(329, 1065);
+            blockMappings.setNewId(850, 750);
+            for (int i = 18900; i <= 18907; i++) {
+                blockStateMappings.setNewId(i, 16082);
+            }
+        }
 
         final ListTag<CompoundTag> chatTypes = BackwardsMappingDataLoader.INSTANCE.loadNBT("chat-types-1.19.1.nbt").getListTag("values", CompoundTag.class);
         for (final CompoundTag chatType : chatTypes) {

--- a/common/src/main/resources/assets/viabackwards/config.yml
+++ b/common/src/main/resources/assets/viabackwards/config.yml
@@ -24,5 +24,9 @@ handle-pings-as-inv-acknowledgements: false
 # Adds bedrock blocks at y=0 for sub 1.17 clients. This may allow for weird interactions due to sending fake blocks.
 bedrock-at-y-0: false
 #
+# Shows sculk shriekers as crying obsidian for 1.18.2 clients on 1.19+ servers. This fixes collision and block breaking issues.
+# If disabled, the client will see them as end portal frames.
+sculk-shriekers-to-crying-obsidian: true
+#
 # Suppresses warnings of missing emulations for certain features that are not supported (e.g. world height in 1.17+).
 suppress-emulation-warnings: false


### PR DESCRIPTION
The current mapping (end portal frame) has two main issues:
- It cannot be broken by players unlike the sculk shrieker block.
- It is not a full block which can cause movement/collision issues.

The reasons I decided against changing the mapping in our Mappings repository but instead adding this option:
- End portal frames are the visual better mapping since they allow us to indicate the shrieking state which isn't possible with the new mapping.
- Other mappings like (sculk_catalyst -> end_stone) are also in the end theme.
- ViaVersion also adds config options / special handling for cases like this: https://github.com/ViaVersion/ViaVersion/blob/master/common/src/main/resources/assets/viaversion/config.yml#L107

Closes https://github.com/ViaVersion/ViaBackwards/issues/618