### PR TITLE
Fix possible NPE in 1.17->1.16.4 bedrock at 0 emulation

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_17to1_16_4/rewriter/BlockItemPacketRewriter1_17.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_17to1_16_4/rewriter/BlockItemPacketRewriter1_17.java
@@ -364,10 +364,12 @@ public final class BlockItemPacketRewriter1_17 extends BackwardsItemRewriter<Cli
 
             if (ViaBackwards.getConfig().bedrockAtY0()) {
                 final ChunkSection lowestSection = chunk.getSections()[0];
-                final DataPalette blocks = lowestSection.palette(PaletteType.BLOCKS);
-                for (int x = 0; x < 16; x++) {
-                    for (int z = 0; z < 16; z++) {
-                        blocks.setIdAt(x, 0, z, BEDROCK_BLOCK_STATE);
+                if (lowestSection != null) {
+                    final DataPalette blocks = lowestSection.palette(PaletteType.BLOCKS);
+                    for (int x = 0; x < 16; x++) {
+                        for (int z = 0; z < 16; z++) {
+                            blocks.setIdAt(x, 0, z, BEDROCK_BLOCK_STATE);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
In case the server returns null for chunk section 0 the code now don't add a layer of bedrock blocks, in theory we could also add section 0 to the chunk, but I believe we'll only have this case on servers where there is void <= 0 (and possible higher) and having a bedrock layer there would look ugly.

_If someone ever complains, we could have a setting to control the behaviour_