### PR TITLE
Handle keep all player attributes boolean in LOGIN in 1.16->1.15.2 

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_16to1_15_2/Protocol1_16To1_15_2.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_16to1_15_2/Protocol1_16To1_15_2.java
@@ -22,6 +22,7 @@ import com.viaversion.viabackwards.api.rewriters.SoundRewriter;
 import com.viaversion.viabackwards.protocol.v1_16to1_15_2.rewriter.TranslatableRewriter1_16;
 import com.viaversion.viabackwards.protocol.v1_16to1_15_2.data.BackwardsMappingData1_16;
 import com.viaversion.viabackwards.protocol.v1_16to1_15_2.rewriter.CommandRewriter1_16;
+import com.viaversion.viabackwards.protocol.v1_16to1_15_2.storage.PlayerAttributesStorage;
 import com.viaversion.viabackwards.protocol.v1_16to1_15_2.storage.WorldNameTracker;
 import com.viaversion.viabackwards.protocol.v1_16to1_15_2.rewriter.BlockItemPacketRewriter1_16;
 import com.viaversion.viabackwards.protocol.v1_16to1_15_2.rewriter.EntityPacketRewriter1_16;
@@ -173,6 +174,7 @@ public class Protocol1_16To1_15_2 extends BackwardsProtocol<ClientboundPackets1_
 
         user.put(new PlayerSneakStorage());
         user.put(new WorldNameTracker());
+        user.put(new PlayerAttributesStorage());
         user.addEntityTracker(this.getClass(), new EntityTrackerBase(user, EntityTypes1_16.PLAYER));
     }
 

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_16to1_15_2/data/BackwardsMappingData1_16.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_16to1_15_2/data/BackwardsMappingData1_16.java
@@ -21,6 +21,7 @@ import com.viaversion.nbt.tag.CompoundTag;
 import com.viaversion.viabackwards.api.data.BackwardsMappingData;
 import com.viaversion.viaversion.protocols.v1_15_2to1_16.Protocol1_15_2To1_16;
 import com.viaversion.viaversion.protocols.v1_15_2to1_16.data.AttributeMappings1_16;
+import com.viaversion.viaversion.util.Key;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,11 +36,11 @@ public class BackwardsMappingData1_16 extends BackwardsMappingData {
     protected void loadExtras(final CompoundTag data) {
         super.loadExtras(data);
         for (Map.Entry<String, String> entry : AttributeMappings1_16.attributeIdentifierMappings().entrySet()) {
-            attributeMappings.put(entry.getValue(), entry.getKey());
+            attributeMappings.put(Key.stripMinecraftNamespace(entry.getValue()), entry.getKey());
         }
     }
 
-    public Map<String, String> attributeIdentifierMappings() {
-        return attributeMappings;
+    public String mappedAttributeIdentifier(final String identifier) {
+        return attributeMappings.getOrDefault(identifier, identifier);
     }
 }

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_16to1_15_2/rewriter/EntityPacketRewriter1_16.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_16to1_15_2/rewriter/EntityPacketRewriter1_16.java
@@ -136,8 +136,8 @@ public class EntityPacketRewriter1_16 extends EntityRewriter<ClientboundPackets1
                     }
 
                     final PlayerAttributesStorage attributes = wrapper.user().get(PlayerAttributesStorage.class);
-                    final boolean keepPlayerData = wrapper.read(Types.BOOLEAN);
-                    if (keepPlayerData) {
+                    final boolean keepPlayerAttributes = wrapper.read(Types.BOOLEAN);
+                    if (keepPlayerAttributes) {
                         // Ensure packet order
                         wrapper.send(Protocol1_16To1_15_2.class);
                         wrapper.cancel();

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_16to1_15_2/rewriter/EntityPacketRewriter1_16.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_16to1_15_2/rewriter/EntityPacketRewriter1_16.java
@@ -210,9 +210,9 @@ public class EntityPacketRewriter1_16 extends EntityRewriter<ClientboundPackets1
                 final int count = wrapper.passthrough(Types.VAR_INT);
                 final var modifiers = new PlayerAttributesStorage.AttributeModifier[count];
                 for (int j = 0; j < count; j++) {
-                    final UUID uuid = wrapper.passthrough(Types.UUID); // UUID
-                    final double amount = wrapper.passthrough(Types.DOUBLE); // Amount
-                    final byte operation = wrapper.passthrough(Types.BYTE); // Operation
+                    final UUID uuid = wrapper.passthrough(Types.UUID);
+                    final double amount = wrapper.passthrough(Types.DOUBLE);
+                    final byte operation = wrapper.passthrough(Types.BYTE);
 
                     modifiers[j] = new PlayerAttributesStorage.AttributeModifier(uuid, amount, operation);
                 }

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_16to1_15_2/storage/PlayerAttributesStorage.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_16to1_15_2/storage/PlayerAttributesStorage.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of ViaBackwards - https://github.com/ViaVersion/ViaBackwards
+ * Copyright (C) 2016-2024 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viabackwards.protocol.v1_16to1_15_2.storage;
+
+import com.viaversion.viabackwards.protocol.v1_16to1_15_2.Protocol1_16To1_15_2;
+import com.viaversion.viaversion.api.connection.StorableObject;
+import com.viaversion.viaversion.api.connection.UserConnection;
+import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
+import com.viaversion.viaversion.api.type.Types;
+import com.viaversion.viaversion.protocols.v1_14_4to1_15.packet.ClientboundPackets1_15;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public final class PlayerAttributesStorage implements StorableObject {
+
+    private final Map<String, Attribute> attributes = new HashMap<>();
+
+    public void sendAttributes(final UserConnection connection, final int entityId) {
+        final PacketWrapper updateAttributes = PacketWrapper.create(ClientboundPackets1_15.UPDATE_ATTRIBUTES, connection);
+
+        updateAttributes.write(Types.VAR_INT, entityId);
+        updateAttributes.write(Types.INT, attributes.size());
+        for (final Map.Entry<String, Attribute> attributeEntry : attributes.entrySet()) {
+            final Attribute attribute = attributeEntry.getValue();
+            updateAttributes.write(Types.STRING, attributeEntry.getKey());
+            updateAttributes.write(Types.DOUBLE, attribute.value());
+            updateAttributes.write(Types.VAR_INT, attribute.modifiers().length);
+
+            for (final AttributeModifier modifier : attribute.modifiers()) {
+                updateAttributes.write(Types.UUID, modifier.uuid());
+                updateAttributes.write(Types.DOUBLE, modifier.amount());
+                updateAttributes.write(Types.BYTE, modifier.operation());
+            }
+        }
+        updateAttributes.send(Protocol1_16To1_15_2.class);
+    }
+
+    public void clearAttributes() {
+        attributes.clear();
+    }
+
+    public void addAttribute(final String key, final Attribute attribute) {
+        attributes.put(key, attribute);
+    }
+
+    public record Attribute(double value, AttributeModifier[] modifiers) {
+    }
+
+    public record AttributeModifier(UUID uuid, double amount, byte operation) {
+    }
+}

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_19to1_18_2/rewriter/EntityPacketRewriter1_19.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_19to1_18_2/rewriter/EntityPacketRewriter1_19.java
@@ -202,7 +202,7 @@ public final class EntityPacketRewriter1_19 extends EntityRewriter<ClientboundPa
                 map(Types.BYTE); // Previous gamemode
                 map(Types.BOOLEAN); // Debug
                 map(Types.BOOLEAN); // Flat
-                map(Types.BOOLEAN); // Keep player data
+                map(Types.BOOLEAN); // Keep player attributes
                 handler(wrapper -> {
                     final GlobalBlockPosition lastDeathPosition = wrapper.read(Types.OPTIONAL_GLOBAL_POSITION);
                     if (lastDeathPosition != null) {


### PR DESCRIPTION
Properly supports the new feature in start game where it's possible to keep player attributes after the respawn. Required for ViaBedrock to work properly with ViaBackwards.