### PR TITLE
Check if item is null in 1.17.1->1.17 book conversion

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_17_1to1_17/Protocol1_17_1To1_17.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_17_1to1_17/Protocol1_17_1To1_17.java
@@ -102,6 +102,12 @@ public final class Protocol1_17_1To1_17 extends BackwardsProtocol<ClientboundPac
             boolean signing = wrapper.read(Types.BOOLEAN);
             wrapper.passthrough(Types.VAR_INT); // Slot comes first
 
+            if (item == null) {
+                wrapper.write(Types.VAR_INT, 0); // Pages length
+                wrapper.write(Types.BOOLEAN, false); // Optional title
+                return;
+            }
+
             CompoundTag tag = item.tag();
             ListTag<StringTag> pagesTag;
             StringTag titleTag = null;


### PR DESCRIPTION
Minecraft uses EMPTY items in 1.11+ which wouldn't produce a NPE when read, since we map them to null we need extra checking.

"Fixes" https://github.com/ViaVersion/ViaVersion/issues/4031