### PR TITLE
Remove ViaFabricPlus as required dependency

### DIFF
--- a/universal/build.gradle.kts
+++ b/universal/build.gradle.kts
@@ -54,9 +54,8 @@ if (!isRelease || isMainBranch) { // Only publish releases from the main branch
         autoAddDependsOn.set(false)
         detectLoaders.set(false)
         dependencies {
-            required.project("viafabric")
-            optional.project("viafabricplus")
-            optional.project("viaversion")
+            required.project("viaversion")
+            optional.project("viafabric")
             optional.project("viarewind")
         }
     }


### PR DESCRIPTION
Since snapshots aren't publicly anymore, VFP only uses ViaBackwards as internal library for ViaAprilFools. I also reverted my ViaFabric/ViaVersion dependency change as apparently plugin managers are breaking by this since they try downloading VF on a Spigot/Paper server.