### PR TITLE
Fix enchantment rewriter description conversion in 1.21->1.20.5

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21to1_20_5/rewriter/BlockItemPacketRewriter1_21.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21to1_20_5/rewriter/BlockItemPacketRewriter1_21.java
@@ -160,7 +160,7 @@ public final class BlockItemPacketRewriter1_21 extends BackwardsStructuredItemRe
 
             final var component = SerializerVersion.V1_20_5.toComponent(description);
             component.getSiblings().add(new StringComponent(" "));
-            component.getSiblings().add(new TranslationComponent("enchantment.level." + level));
+            component.getSiblings().add(new TranslationComponent(EnchantmentRewriter.ENCHANTMENT_LEVEL_TRANSLATION.formatted(level)));
 
             return SerializerVersion.V1_20_5.toTag(component);
         };

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21to1_20_5/rewriter/BlockItemPacketRewriter1_21.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21to1_20_5/rewriter/BlockItemPacketRewriter1_21.java
@@ -39,6 +39,8 @@ import com.viaversion.viaversion.api.type.types.chunk.ChunkType1_20_2;
 import com.viaversion.viaversion.api.type.types.version.Types1_20_5;
 import com.viaversion.viaversion.api.type.types.version.Types1_21;
 import com.viaversion.viaversion.libs.fastutil.ints.Int2IntMap;
+import com.viaversion.viaversion.libs.mcstructs.text.components.StringComponent;
+import com.viaversion.viaversion.libs.mcstructs.text.components.TranslationComponent;
 import com.viaversion.viaversion.protocols.v1_20_2to1_20_3.rewriter.RecipeRewriter1_20_3;
 import com.viaversion.viaversion.protocols.v1_20_3to1_20_5.data.Enchantments1_20_5;
 import com.viaversion.viaversion.protocols.v1_20_3to1_20_5.packet.ServerboundPacket1_20_5;
@@ -47,8 +49,8 @@ import com.viaversion.viaversion.protocols.v1_20_5to1_21.packet.ClientboundPacke
 import com.viaversion.viaversion.protocols.v1_20_5to1_21.packet.ClientboundPackets1_21;
 import com.viaversion.viaversion.rewriter.BlockRewriter;
 import com.viaversion.viaversion.rewriter.IdRewriteFunction;
+import com.viaversion.viaversion.util.SerializerVersion;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static com.viaversion.viaversion.protocols.v1_20_5to1_21.rewriter.BlockItemPacketRewriter1_21.downgradeItemData;
@@ -156,10 +158,11 @@ public final class BlockItemPacketRewriter1_21 extends BackwardsStructuredItemRe
                 return new StringTag("Unknown enchantment");
             }
 
-            final CompoundTag fullDescription = new CompoundTag();
-            fullDescription.putString("translate", "%s %s");
-            fullDescription.put("with", new ListTag<>(Arrays.asList(description, new StringTag(EnchantmentRewriter.ENCHANTMENT_LEVEL_TRANSLATION.formatted(level)))));
-            return fullDescription;
+            final var component = SerializerVersion.V1_20_5.toComponent(description);
+            component.getSiblings().add(new StringComponent(" "));
+            component.getSiblings().add(new TranslationComponent("enchantment.level." + level));
+
+            return SerializerVersion.V1_20_5.toTag(component);
         };
         enchantmentRewriter.rewriteEnchantmentsToClient(data, StructuredDataKey.ENCHANTMENTS, idRewriteFunction, descriptionSupplier, false);
         enchantmentRewriter.rewriteEnchantmentsToClient(data, StructuredDataKey.STORED_ENCHANTMENTS, idRewriteFunction, descriptionSupplier, true);


### PR DESCRIPTION
Handles all types the description field can be while still keeping the enchantment level as translatable.

Closes https://github.com/ViaVersion/ViaVersion/issues/4039