### PR TITLE
Handle data->pitch/yaw item frame rotation change in 1.17->1.16.4

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_17to1_16_4/rewriter/EntityPacketRewriter1_17.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_17to1_16_4/rewriter/EntityPacketRewriter1_17.java
@@ -80,8 +80,8 @@ public final class EntityPacketRewriter1_17 extends EntityRewriter<ClientboundPa
                         case 4 /* west */ -> yaw = 90F;
                         case 5 /* east */ -> yaw = 270;
                     }
-                    wrapper.set(Types.BYTE, 0, (byte) (pitch * 256.0F / 360.0F));
-                    wrapper.set(Types.BYTE, 1, (byte) (yaw * 256.0F / 360.0F));
+                    wrapper.set(Types.BYTE, 0, (byte) (pitch * 256F / 360F));
+                    wrapper.set(Types.BYTE, 1, (byte) (yaw * 256F / 360F));
                 });
                 handler(getSpawnTrackerWithDataHandler(EntityTypes1_17.FALLING_BLOCK));
             }


### PR DESCRIPTION
Older clients will ignore the data field and the server sets the item frame rotation by the yaw/pitch field inside the packet, newer clients do the opposite and ignore yaw/pitch and use the data field from the packet. Therefore, we need to restore that logic.

Closes https://github.com/ViaVersion/ViaBackwards/issues/843