### PR TITLE
Fix map color rewriting not working for 1.17 -> 1.16.4

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/api/rewriters/MapColorRewriter.java
+++ b/common/src/main/java/com/viaversion/viabackwards/api/rewriters/MapColorRewriter.java
@@ -30,15 +30,17 @@ public final class MapColorRewriter {
      * @param rewriter id rewriter returning mapped colors, or -1 if unmapped
      * @return packethandler to rewrite map data color ids
      */
-    public static PacketHandler getRewriteHandler(IdRewriteFunction rewriter) {
+    public static PacketHandler getRewriteHandler(IdRewriteFunction rewriter, boolean icons) {
         return wrapper -> {
-            int iconCount = wrapper.passthrough(Types.VAR_INT);
-            for (int i = 0; i < iconCount; i++) {
-                wrapper.passthrough(Types.VAR_INT); // Type
-                wrapper.passthrough(Types.BYTE); // X
-                wrapper.passthrough(Types.BYTE); // Z
-                wrapper.passthrough(Types.BYTE); // Direction
-                wrapper.passthrough(Types.OPTIONAL_COMPONENT); // Display Name
+            if (icons) {
+                int iconCount = wrapper.passthrough(Types.VAR_INT);
+                for (int i = 0; i < iconCount; i++) {
+                    wrapper.passthrough(Types.VAR_INT); // Type
+                    wrapper.passthrough(Types.BYTE); // X
+                    wrapper.passthrough(Types.BYTE); // Z
+                    wrapper.passthrough(Types.BYTE); // Direction
+                    wrapper.passthrough(Types.OPTIONAL_COMPONENT); // Display Name
+                }
             }
 
             short columns = wrapper.passthrough(Types.UNSIGNED_BYTE);

--- a/common/src/main/java/com/viaversion/viabackwards/api/rewriters/MapColorRewriter.java
+++ b/common/src/main/java/com/viaversion/viabackwards/api/rewriters/MapColorRewriter.java
@@ -17,12 +17,46 @@
  */
 package com.viaversion.viabackwards.api.rewriters;
 
+import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandler;
-import com.viaversion.viaversion.api.type.Type;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.rewriter.IdRewriteFunction;
 
 public final class MapColorRewriter {
+
+    /**
+     * Rewrite map colors using the provided id rewriter.
+     *
+     * @param wrapper   packet wrapper
+     * @param rewriter  id rewriter returning mapped colors, or -1 if unmapped
+     * @param iconCount number of icons to read
+     */
+    public static void rewriteMapColors(PacketWrapper wrapper, IdRewriteFunction rewriter, int iconCount) {
+        for (int i = 0; i < iconCount; i++) {
+            wrapper.passthrough(Types.VAR_INT); // Type
+            wrapper.passthrough(Types.BYTE); // X
+            wrapper.passthrough(Types.BYTE); // Z
+            wrapper.passthrough(Types.BYTE); // Direction
+            wrapper.passthrough(Types.OPTIONAL_COMPONENT); // Display Name
+        }
+
+        short columns = wrapper.passthrough(Types.UNSIGNED_BYTE);
+        if (columns < 1) {
+            return;
+        }
+
+        wrapper.passthrough(Types.UNSIGNED_BYTE); // Rows
+        wrapper.passthrough(Types.UNSIGNED_BYTE); // X
+        wrapper.passthrough(Types.UNSIGNED_BYTE); // Z
+        byte[] data = wrapper.passthrough(Types.BYTE_ARRAY_PRIMITIVE);
+        for (int i = 0; i < data.length; i++) {
+            int color = data[i] & 0xFF;
+            int mappedColor = rewriter.rewrite(color);
+            if (mappedColor != -1) {
+                data[i] = (byte) mappedColor;
+            }
+        }
+    }
 
     /**
      * Returns a packethandler to rewrite map data color ids. Reading starts from the icon count.
@@ -30,33 +64,7 @@ public final class MapColorRewriter {
      * @param rewriter id rewriter returning mapped colors, or -1 if unmapped
      * @return packethandler to rewrite map data color ids
      */
-    public static PacketHandler getRewriteHandler(IdRewriteFunction rewriter, boolean icons) {
-        return wrapper -> {
-            if (icons) {
-                int iconCount = wrapper.passthrough(Types.VAR_INT);
-                for (int i = 0; i < iconCount; i++) {
-                    wrapper.passthrough(Types.VAR_INT); // Type
-                    wrapper.passthrough(Types.BYTE); // X
-                    wrapper.passthrough(Types.BYTE); // Z
-                    wrapper.passthrough(Types.BYTE); // Direction
-                    wrapper.passthrough(Types.OPTIONAL_COMPONENT); // Display Name
-                }
-            }
-
-            short columns = wrapper.passthrough(Types.UNSIGNED_BYTE);
-            if (columns < 1) return;
-
-            wrapper.passthrough(Types.UNSIGNED_BYTE); // Rows
-            wrapper.passthrough(Types.UNSIGNED_BYTE); // X
-            wrapper.passthrough(Types.UNSIGNED_BYTE); // Z
-            byte[] data = wrapper.passthrough(Types.BYTE_ARRAY_PRIMITIVE);
-            for (int i = 0; i < data.length; i++) {
-                int color = data[i] & 0xFF;
-                int mappedColor = rewriter.rewrite(color);
-                if (mappedColor != -1) {
-                    data[i] = (byte) mappedColor;
-                }
-            }
-        };
+    public static PacketHandler getRewriteHandler(IdRewriteFunction rewriter) {
+        return wrapper -> rewriteMapColors(wrapper, rewriter, wrapper.passthrough(Types.VAR_INT));
     }
 }

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_16to1_15_2/rewriter/BlockItemPacketRewriter1_16.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_16to1_15_2/rewriter/BlockItemPacketRewriter1_16.java
@@ -206,7 +206,7 @@ public class BlockItemPacketRewriter1_16 extends BackwardsItemRewriter<Clientbou
                 map(Types.BYTE); // Scale
                 map(Types.BOOLEAN); // Tracking Position
                 map(Types.BOOLEAN); // Locked
-                handler(MapColorRewriter.getRewriteHandler(MapColorMappings1_15_2::getMappedColor));
+                handler(MapColorRewriter.getRewriteHandler(MapColorMappings1_15_2::getMappedColor, true));
             }
         });
 

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_17to1_16_4/rewriter/BlockItemPacketRewriter1_17.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_17to1_16_4/rewriter/BlockItemPacketRewriter1_17.java
@@ -422,11 +422,15 @@ public final class BlockItemPacketRewriter1_17 extends BackwardsItemRewriter<Cli
                 handler(wrapper -> wrapper.write(Types.BOOLEAN, true)); // Tracking position
                 map(Types.BOOLEAN); // Locked
                 handler(wrapper -> {
-                    boolean hasMarkers = wrapper.read(Types.BOOLEAN);
-                    if (!hasMarkers) {
-                        wrapper.write(Types.VAR_INT, 0); // Array size
+                    final int iconCount;
+                    final boolean hasMarkers = wrapper.read(Types.BOOLEAN);
+                    if (hasMarkers) {
+                        iconCount = wrapper.passthrough(Types.VAR_INT);
+                    } else {
+                        wrapper.write(Types.VAR_INT, 0); // Add icon count
+                        iconCount = 0;
                     }
-                    MapColorRewriter.getRewriteHandler(MapColorMappings1_16_4::getMappedColor, hasMarkers).handle(wrapper);
+                    MapColorRewriter.rewriteMapColors(wrapper, MapColorMappings1_16_4::getMappedColor, iconCount);
                 });
             }
         });

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_17to1_16_4/rewriter/BlockItemPacketRewriter1_17.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_17to1_16_4/rewriter/BlockItemPacketRewriter1_17.java
@@ -425,9 +425,8 @@ public final class BlockItemPacketRewriter1_17 extends BackwardsItemRewriter<Cli
                     boolean hasMarkers = wrapper.read(Types.BOOLEAN);
                     if (!hasMarkers) {
                         wrapper.write(Types.VAR_INT, 0); // Array size
-                    } else {
-                        MapColorRewriter.getRewriteHandler(MapColorMappings1_16_4::getMappedColor).handle(wrapper);
                     }
+                    MapColorRewriter.getRewriteHandler(MapColorMappings1_16_4::getMappedColor, hasMarkers).handle(wrapper);
                 });
             }
         });


### PR DESCRIPTION
Map color rewriting was only working when the map data packet would have decorations