### PR TITLE
Remap COPY_TO_CLIPBOARD click event to SUGGEST_COMMAND in 1.16->1.15.2

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_16to1_15_2/rewriter/TranslatableRewriter1_16.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_16to1_15_2/rewriter/TranslatableRewriter1_16.java
@@ -70,6 +70,14 @@ public class TranslatableRewriter1_16 extends JsonNBTComponentRewriter<Clientbou
             }
         }
 
+        JsonObject clickEvent = object.getAsJsonObject("clickEvent");
+        if (clickEvent != null && clickEvent.has("action")) {
+            String action = clickEvent.get("action").getAsString();
+            if (action.equals("copy_to_clipboard")) {
+                clickEvent.addProperty("action", "suggest_command");
+            }
+        }
+
         JsonObject hoverEvent = object.getAsJsonObject("hoverEvent");
         if (hoverEvent == null || !hoverEvent.has("contents")) {
             return;


### PR DESCRIPTION
Also fixes a crash caused by MCStructs 3.0.0+ throwing errors in serializers on unknown click/hover events (copy to clipboard added in 1.16+ in this case).

Closes https://github.com/ViaVersion/ViaBackwards/issues/981