### PR TITLE
Fix login finished packet in 1.19->1.18.2

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_19to1_18_2/Protocol1_19To1_18_2.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_19to1_18_2/Protocol1_19To1_18_2.java
@@ -296,7 +296,7 @@ public final class Protocol1_19To1_18_2 extends BackwardsProtocol<ClientboundPac
             public void register() {
                 map(Types.UUID); // UUID
                 map(Types.STRING); // Name
-                map(Types.PROFILE_PROPERTY_ARRAY);
+                read(Types.PROFILE_PROPERTY_ARRAY);
             }
         });
 


### PR DESCRIPTION
Tested with 1.18.2 client on 1.21.5 server.

See https://github.com/ViaVersion/ViaBackwards/commit/8669c17512cd4ca3cd9ce6eec0d3a8def49a1603#diff-f02e9b242cffed64f3a8d514408b1b26f2078d7a9533f724eec1012cb382fa2f