### PR TITLE
Ensure run_command click events start with '/' in 1.21.5->1.21.4

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_5to1_21_4/rewriter/ComponentRewriter1_21_5.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_5to1_21_4/rewriter/ComponentRewriter1_21_5.java
@@ -81,7 +81,14 @@ public final class ComponentRewriter1_21_5 extends NBTComponentRewriter<Clientbo
         switch (action) {
             case "open_url" -> clickEventTag.put("value", clickEventTag.getStringTag("url"));
             case "change_page" -> clickEventTag.putString("value", Integer.toString(clickEventTag.getInt("page")));
-            case "run_command", "suggest_command" -> clickEventTag.put("value", clickEventTag.getStringTag("command"));
+            case "run_command" -> {
+                final StringTag command = clickEventTag.getStringTag("command");
+                if (command != null && !command.getValue().startsWith("/")) {
+                    command.setValue("/" + command.getValue());
+                }
+                clickEventTag.put("value", command);
+            }
+            case "suggest_command" -> clickEventTag.put("value", clickEventTag.getStringTag("command"));
         }
     }
 


### PR DESCRIPTION
> It is no longer required that the specified command field has a / prefix

https://www.minecraft.net/en-us/article/minecraft-java-edition-1-21-5