### PR TITLE
Fix read any NBT tag for SERVER_LINKS link key to keep 1.21.5 clients compatible

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_6to1_21_5/Protocol1_21_6To1_21_5.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_6to1_21_5/Protocol1_21_6To1_21_5.java
@@ -305,7 +305,7 @@ public final class Protocol1_21_6To1_21_5 extends BackwardsProtocol<ClientboundP
                 final String url = wrapper.passthrough(Types.STRING);
                 serverLinks.storeLink(id, url);
             } else {
-                final Tag tag = wrapper.passthrough(Types.COMPOUND_TAG);
+                final Tag tag = wrapper.passthrough(Types.TAG);
                 final String url = wrapper.passthrough(Types.STRING);
                 serverLinks.storeLink(tag, url);
             }


### PR DESCRIPTION
**Fix this error**
https://mclo.gs/RMEOJBV

- Change: replace Types.COMPOUND_TAG with Types.TAG in storeServerLinks;
- Reason: 1.21.7+ can send StringTag (id 8) as root tag;
- Result: fixes EncoderException/InformativeException when 1.21.5 client is connected;
- Tested.