### PR TITLE
fix world border lerp size set in ticks instead of millis

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_11to1_21_9/rewriter/BlockItemPacketRewriter1_21_11.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_11to1_21_9/rewriter/BlockItemPacketRewriter1_21_11.java
@@ -94,9 +94,6 @@ public final class BlockItemPacketRewriter1_21_11 extends BackwardsStructuredIte
             wrapper.passthrough(Types.DOUBLE); // oldSize
             wrapper.passthrough(Types.DOUBLE); // newSize
             wrapper.write(Types.VAR_LONG, wrapper.read(Types.VAR_LONG) * 50); // lerpTime
-            wrapper.passthrough(Types.VAR_INT); // newAbsoluteMaxSize
-            wrapper.passthrough(Types.VAR_INT); // warningBlocks
-            wrapper.passthrough(Types.VAR_INT); // warningTime
         });
         protocol.registerClientbound(ClientboundPackets1_21_11.SET_TIME, wrapper -> {
             final long gameTime = wrapper.passthrough(Types.LONG);


### PR DESCRIPTION
same as https://github.com/ViaVersion/ViaVersion/pull/4757