### PR TITLE
Fix some older client issues for mannequins

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_9to1_21_7/rewriter/EntityPacketRewriter1_21_9.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_9to1_21_7/rewriter/EntityPacketRewriter1_21_9.java
@@ -470,12 +470,10 @@ public final class EntityPacketRewriter1_21_9 extends EntityRewriter<Clientbound
                     equipment.send(Protocol1_21_9To1_21_7.class);
                 }
 
-                {
-                    final PacketWrapper setHeadRotation = PacketWrapper.create(ClientboundPackets1_21_6.ROTATE_HEAD, event.user());
-                    setHeadRotation.write(Types.VAR_INT, event.entityId());
-                    setHeadRotation.write(Types.BYTE, mannequinData.headYaw());
-                    setHeadRotation.send(Protocol1_21_9To1_21_7.class);
-                }
+                final PacketWrapper setHeadRotation = PacketWrapper.create(ClientboundPackets1_21_6.ROTATE_HEAD, event.user());
+                setHeadRotation.write(Types.VAR_INT, event.entityId());
+                setHeadRotation.write(Types.BYTE, mannequinData.headYaw());
+                setHeadRotation.send(Protocol1_21_9To1_21_7.class);
 
                 if (!isBundling) {
                     final PacketWrapper bundleStart = PacketWrapper.create(ClientboundPackets1_21_6.BUNDLE_DELIMITER, event.user());


### PR DESCRIPTION

First of all, properly track set has team so we dont resend the team on name change.
On older clients, this would cause an exception to be thrown so names wont be shown.

Additionally do use the actual profile name always, that causes us to lose our cool player names. I dont really know why this was added, but this broke stuff.


PLUS, resend the player head rotation. As older clients need to have the player head rotation sent as player entities dont handle the head rotation correctly in the spawn packet (iirc, this was a REALLY old bug)