### PR TITLE
Fix short overflow in legacy velocity handling

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_2to1_21/rewriter/EntityPacketRewriter1_21_2.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_2to1_21/rewriter/EntityPacketRewriter1_21_2.java
@@ -28,6 +28,7 @@ import com.viaversion.viabackwards.api.rewriters.EntityRewriter;
 import com.viaversion.viabackwards.protocol.v1_21_2to1_21.Protocol1_21_2To1_21;
 import com.viaversion.viabackwards.protocol.v1_21_2to1_21.storage.PlayerStorage;
 import com.viaversion.viabackwards.protocol.v1_21_2to1_21.storage.SignStorage;
+import com.viaversion.viabackwards.utils.VelocityUtil;
 import com.viaversion.viaversion.api.data.entity.EntityTracker;
 import com.viaversion.viaversion.api.minecraft.Holder;
 import com.viaversion.viaversion.api.minecraft.Particle;
@@ -548,9 +549,9 @@ public final class EntityPacketRewriter1_21_2 extends EntityRewriter<Clientbound
         } else if (!relativeDeltaX && !relativeDeltaY && !relativeDeltaZ) {
             final PacketWrapper entityMotionPacket = wrapper.create(ClientboundPackets1_21.SET_ENTITY_MOTION);
             entityMotionPacket.write(Types.VAR_INT, entityId != null ? entityId : tracker(wrapper.user()).clientEntityId());
-            entityMotionPacket.write(Types.SHORT, (short) (movementX * 8000));
-            entityMotionPacket.write(Types.SHORT, (short) (movementY * 8000));
-            entityMotionPacket.write(Types.SHORT, (short) (movementZ * 8000));
+            entityMotionPacket.write(Types.SHORT, VelocityUtil.toLegacyVelocity(movementX));
+            entityMotionPacket.write(Types.SHORT, VelocityUtil.toLegacyVelocity(movementY));
+            entityMotionPacket.write(Types.SHORT, VelocityUtil.toLegacyVelocity(movementZ));
 
             entityMotionPacket.send(Protocol1_21_2To1_21.class);
         } else if (!warned) {

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_9to1_21_7/rewriter/EntityPacketRewriter1_21_9.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_9to1_21_7/rewriter/EntityPacketRewriter1_21_9.java
@@ -25,6 +25,7 @@ import com.viaversion.viabackwards.protocol.v1_21_9to1_21_7.Protocol1_21_9To1_21
 import com.viaversion.viabackwards.protocol.v1_21_9to1_21_7.storage.MannequinData;
 import com.viaversion.viabackwards.protocol.v1_21_9to1_21_7.storage.PlayerRotationStorage;
 import com.viaversion.viabackwards.protocol.v1_21_9to1_21_7.tracker.EntityTracker1_21_9;
+import com.viaversion.viabackwards.utils.VelocityUtil;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.data.entity.TrackedEntity;
 import com.viaversion.viaversion.api.minecraft.BlockPosition;
@@ -329,9 +330,9 @@ public final class EntityPacketRewriter1_21_9 extends EntityRewriter<Clientbound
     }
 
     private void writeMovementShorts(final PacketWrapper wrapper, final Vector3d movement) {
-        wrapper.write(Types.SHORT, (short) (movement.x() * 8000));
-        wrapper.write(Types.SHORT, (short) (movement.y() * 8000));
-        wrapper.write(Types.SHORT, (short) (movement.z() * 8000));
+        wrapper.write(Types.SHORT, VelocityUtil.toLegacyVelocity(movement.x()));
+        wrapper.write(Types.SHORT, VelocityUtil.toLegacyVelocity(movement.y()));
+        wrapper.write(Types.SHORT, VelocityUtil.toLegacyVelocity(movement.z()));
     }
 
     private void storePlayerRotation(final PacketWrapper wrapper) {

--- a/common/src/main/java/com/viaversion/viabackwards/utils/VelocityUtil.java
+++ b/common/src/main/java/com/viaversion/viabackwards/utils/VelocityUtil.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of ViaBackwards - https://github.com/ViaVersion/ViaBackwards
+ * Copyright (C) 2016-2026 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viabackwards.utils;
+
+public class VelocityUtil {
+
+    public static short toLegacyVelocity(double value) {
+        return (short) Math.max(Short.MIN_VALUE, Math.min(Short.MAX_VALUE, (long) (value * 8000)));
+    }
+
+}


### PR DESCRIPTION
Clamp the velocity conversion result to the valid short range to prevent overflow and invalid velocity values