### PR TITLE
Fix incorrect Frog and Cat variant mappings (1.21.5->1.21.4)

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_5to1_21_4/rewriter/EntityPacketRewriter1_21_5.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_5to1_21_4/rewriter/EntityPacketRewriter1_21_5.java
@@ -170,28 +170,30 @@ public final class EntityPacketRewriter1_21_5 extends EntityRewriter<Clientbound
                 return;
             } else if (id == entityDataTypes.frogVariantType.typeId()) {
                 final int value = data.value();
-                int newValue = switch (value) {
-                    case 0 -> 2; // minecraft:cold
-                    case 1 -> 0; // minecraft:temperate
-                    case 2 -> 1; // minecraft:warm
+                final String variantKey = protocol.getRegistryDataRewriter().getMappings("frog_variant").idToKey(value);
+                final int newValue = (variantKey == null) ? 0 : switch (variantKey) {
+                    case "cold" -> 2;
+                    case "temperate" -> 0;
+                    case "warm" -> 1;
                     default -> 0;
                 };
                 data.setTypeAndValue(mappedEntityDataTypes.frogVariantType, newValue);
                 return;
             } else if (id == entityDataTypes.catVariantType.typeId()) {
                 final int value = data.value();
-                int newValue = switch (value) {
-                    case 0 -> 10; // minecraft:all_black
-                    case 1 -> 1;  // minecraft:black
-                    case 2 -> 4;  // minecraft:british_shorthair
-                    case 3 -> 5;  // minecraft:calico
-                    case 4 -> 9;  // minecraft:jellie
-                    case 5 -> 6;  // minecraft:persian
-                    case 6 -> 7;  // minecraft:ragdoll
-                    case 7 -> 2;  // minecraft:red
-                    case 8 -> 3;  // minecraft:siamese
-                    case 9 -> 0;  // minecraft:tabby
-                    case 10 -> 8; // minecraft:white
+                final String variantKey = protocol.getRegistryDataRewriter().getMappings("cat_variant").idToKey(value);
+                final int newValue = (variantKey == null) ? 1 : switch (variantKey) {
+                    case "all_black" -> 10;
+                    case "black" -> 1;
+                    case "british_shorthair" -> 4;
+                    case "calico" -> 5;
+                    case "jellie" -> 9;
+                    case "persian" -> 6;
+                    case "ragdoll" -> 7;
+                    case "red" -> 2;
+                    case "siamese" -> 3;
+                    case "tabby" -> 0;
+                    case "white" -> 8;
                     default -> 1;
                 };
                 data.setTypeAndValue(mappedEntityDataTypes.catVariantType, newValue);


### PR DESCRIPTION
This PR fixes an issue where Frog and Cat variants were displayed incorrectly on 1.21.4 (and below) clients when connecting to a 1.21.5+ server.

Fixes https://github.com/ViaVersion/ViaBackwards/issues/1145