### PR TITLE
fix: remove 1.21.11-specific registry types unknown to older clients

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_11to1_21_9/Protocol1_21_11To1_21_9.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_11to1_21_9/Protocol1_21_11To1_21_9.java
@@ -231,9 +231,22 @@ public final class Protocol1_21_11To1_21_9 extends BackwardsProtocol<Clientbound
         });
         registryDataRewriter.remove("zombie_nautilus_variant");
         registryDataRewriter.remove("timeline");
+        registryDataRewriter.remove("wolf_sound_variant");
+        registryDataRewriter.remove("chicken_variant");
+        registryDataRewriter.remove("cow_variant");
+        registryDataRewriter.remove("pig_variant");
+        registryDataRewriter.remove("jukebox_song");
+        registryDataRewriter.remove("dialog");
         registerClientbound(ClientboundConfigurationPackets1_21_9.REGISTRY_DATA, registryDataRewriter::handle);
 
+        tagRewriter.removeTags("zombie_nautilus_variant");
         tagRewriter.removeTags("timeline");
+        tagRewriter.removeTags("wolf_sound_variant");
+        tagRewriter.removeTags("chicken_variant");
+        tagRewriter.removeTags("cow_variant");
+        tagRewriter.removeTags("pig_variant");
+        tagRewriter.removeTags("jukebox_song");
+        tagRewriter.removeTags("dialog");
         tagRewriter.registerGeneric(ClientboundPackets1_21_11.UPDATE_TAGS);
         tagRewriter.registerGeneric(ClientboundConfigurationPackets1_21_9.UPDATE_TAGS);
 


### PR DESCRIPTION
## Summary
- Remove 6 registry types added in 1.21.11 that are not handled by `Protocol1_21_11To1_21_9`, causing `Missing registry` errors on 1.20.5–1.21.10 clients: `wolf_sound_variant`, `chicken_variant`, `cow_variant`, `pig_variant`, `jukebox_song`, `dialog`
- Also remove corresponding tags via `tagRewriter.removeTags()`

## Test plan
- [x] Connect with 1.20.5 client to 1.21.11 server via ViaVersion+ViaBackwards proxy
- [x] Verify no `Missing registry` errors on client

Fixes #1224

🤖 Generated with [Claude Code](https://claude.ai/claude-code)