### PR TITLE
Fix NPE in BlockRewriter1_20_2 when block entity has null tag

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_20_2to1_20/rewriter/BlockRewriter1_20_2.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_20_2to1_20/rewriter/BlockRewriter1_20_2.java
@@ -41,6 +41,9 @@ public final class BlockRewriter1_20_2 extends BlockRewriter<ClientboundPackets1
     @Override
     public void handleBlockEntity(final UserConnection connection, final BlockEntity blockEntity) {
         final CompoundTag tag = blockEntity.tag();
+        if (tag == null) {
+            return;
+        }
         final Tag primaryEffect = tag.remove("primary_effect");
         if (primaryEffect instanceof StringTag) {
             final String effectKey = Key.stripMinecraftNamespace(((StringTag) primaryEffect).getValue());


### PR DESCRIPTION
The error occurred when you placed a bed using the Minecraft 1.18.2 client on a server that was originally running version 1.20.4.