### PR TITLE
scaling new baby mob entities down on older clients

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/api/entities/EntityScaleData.java
+++ b/common/src/main/java/com/viaversion/viabackwards/api/entities/EntityScaleData.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of ViaBackwards - https://github.com/ViaVersion/ViaBackwards
+ * Copyright (C) 2016-2026 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viabackwards.api.entities;
+
+
+import com.viaversion.viaversion.api.data.entity.StoredEntityData;
+
+/**
+ * Storage object used within {@link StoredEntityData} to track the scaling state of an entity.
+ * This ensures that scale updates are only sent when the calculated scale actually changes.
+ */
+public final class EntityScaleData {
+
+    private boolean isBaby;
+    private float scale = 1.0f;
+
+    public boolean isBaby() {
+        return isBaby;
+    }
+
+    public void setBaby(boolean baby) {
+        this.isBaby = baby;
+    }
+
+    public float scale() {
+        return scale;
+    }
+
+    public void setScale(float scale) {
+        this.scale = scale;
+    }
+}

--- a/common/src/main/java/com/viaversion/viabackwards/api/entities/EntityScaleHelper.java
+++ b/common/src/main/java/com/viaversion/viabackwards/api/entities/EntityScaleHelper.java
@@ -18,7 +18,7 @@
 package com.viaversion.viabackwards.api.entities;
 
 
-import com.viaversion.viaversion.api.Via;
+import com.google.common.base.Preconditions;
 import com.viaversion.viaversion.api.data.FullMappings;
 import com.viaversion.viaversion.api.data.entity.StoredEntityData;
 import com.viaversion.viaversion.api.minecraft.entities.EntityType;
@@ -27,100 +27,78 @@ import com.viaversion.viaversion.api.protocol.Protocol;
 import com.viaversion.viaversion.api.protocol.packet.ClientboundPacketType;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.type.Types;
+import com.viaversion.viaversion.rewriter.EntityRewriter;
 import com.viaversion.viaversion.rewriter.entitydata.EntityDataHandlerEvent;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
- * A modular helper for injecting entity scaling on older clients via metadata interception.
- * This helper listens for the isBaby metadata flag and injects an UPDATE_ATTRIBUTES packet
+ * A helper for injecting entity scaling on older clients.
+ * This helper listens for the baby entity data flag and sends an UPDATE_ATTRIBUTES packet
  * to scale the entity, since older clients might not support the newer entity variants natively.
  */
 public class EntityScaleHelper {
 
-    private static final class BabyScale {
-        private final float scaleFactor;
-        private final int index;
-
-        private BabyScale(float scaleFactor, int index) {
-            this.scaleFactor = scaleFactor;
-            this.index = index;
-        }
-    }
-
-    private final Map<EntityType, BabyScale> babyScales = new HashMap<>();
     private final ClientboundPacketType updateAttributesPacket;
+    private final EntityRewriter<?, ?> rewriter;
 
-    public EntityScaleHelper(ClientboundPacketType updateAttributesPacket) {
+    /**
+     * Constructs a new entity scale helper.
+     *
+     * @param rewriter               entity rewriter
+     * @param updateAttributesPacket UPDATE_ATTRIBUTES packet of the mapped protocol
+     * @param <CM>                   mapped clientbound packet type
+     */
+    public <CM extends ClientboundPacketType, P extends Protocol<?, CM, ?, ?>> EntityScaleHelper(final EntityRewriter<?, P> rewriter, final CM updateAttributesPacket) {
+        this.rewriter = rewriter;
         this.updateAttributesPacket = updateAttributesPacket;
     }
 
     /**
      * Registers a scaling factor for a specific baby entity type.
-     * 
-     * @param type The entity type that requires scaling when it is a baby.
-     * @param babyScaleFactor The multiplier to apply to the minecraft:scale attribute when it is a baby.
-     * @param babyIndex The metadata index for the is_baby property in this specific protocol
+     *
+     * @param type            entity type that requires scaling when it is a baby
+     * @param babyScaleFactor multiplier to apply to the minecraft:scale attribute when it is a baby
+     * @param babyIndex       entity data index for the baby property in this specific protocol
      */
-    public void addBabyScale(EntityType type, float babyScaleFactor, int babyIndex) {
-        babyScales.put(type, new BabyScale(babyScaleFactor, babyIndex));
-    }
-
-    public Iterable<EntityType> getRegisteredTypes() {
-        return babyScales.keySet();
+    public void addBabyScale(final EntityType type, final float babyScaleFactor, final int babyIndex) {
+        rewriter.filter().type(type).index(babyIndex).handler(((event, data) -> trackAndSend(event, data, babyScaleFactor)));
     }
 
     /**
-     * Checks the metadata, tracks the scale state natively, and injects an UPDATE_ATTRIBUTES
-     * packet down the pipeline right as the metadata is processed by the client.
+     * Checks the entity data, tracks the scale state and sends an UPDATE_ATTRIBUTES packet if needed.
      */
-    public void trackAndInject(final EntityDataHandlerEvent event, final EntityData data, final Protocol<?, ?, ?, ?> protocol) {
-        final StoredEntityData storedEntityData = event.user().getEntityTracker(protocol.getClass()).entityData(event.entityId());
-        if (storedEntityData == null) return;
-                  
-        final BabyScale babyScale = babyScales.get(storedEntityData.type());
-        if (babyScale == null || data.id() != babyScale.index || !(data.value() instanceof Boolean)) {
+    public void trackAndSend(final EntityDataHandlerEvent event, final EntityData data, final float babyScaleFactor) {
+        if (event.trackedEntity() == null) {
             return;
         }
 
+        final StoredEntityData storedEntityData = event.trackedEntity().data();
         EntityScaleData scaleData = storedEntityData.get(EntityScaleData.class);
         if (scaleData == null) {
             scaleData = new EntityScaleData();
             storedEntityData.put(scaleData);
         }
-        
-        final boolean isBaby = (Boolean) data.value();
-        final float scale = isBaby ? babyScale.scaleFactor : 1.0f;
-        
-        if (scaleData.isBaby() != isBaby || scaleData.scale() != scale) {
-            scaleData.setBaby(isBaby);
-            scaleData.setScale(scale);
-            
-            final FullMappings attributeMappings = protocol.getMappingData().getAttributeMappings();
-            if (attributeMappings == null) return;
-            
-            int unmappedId = attributeMappings.id("minecraft:scale");
-            if (unmappedId == -1) {
-                unmappedId = attributeMappings.id("minecraft:generic.scale");
-                if (unmappedId == -1) {
-                    unmappedId = attributeMappings.id("generic.scale");
-                }
-            }
-            
-            final int mappedId = unmappedId != -1 ? protocol.getMappingData().getNewAttributeId(unmappedId) : -1;
-            
-            if (mappedId != -1) {
-                final PacketWrapper updatePacket = PacketWrapper.create(updateAttributesPacket, event.user());
-                updatePacket.write(Types.VAR_INT, event.entityId());
-                updatePacket.write(Types.VAR_INT, 1); // 1 attribute
-                updatePacket.write(Types.VAR_INT, mappedId);
-                updatePacket.write(Types.DOUBLE, (double) scaleData.scale());
-                updatePacket.write(Types.VAR_INT, 0); // 0 modifiers
-                updatePacket.scheduleSend(protocol.getClass());
-            } else if (Via.getManager().isDebug()) {
-                protocol.getLogger().warning("Scale mapping not found for EntityScaleHelper, baby scaling won't be applied. It's harmless unless you're using custom mappings.");
-            }
+
+        final boolean isBaby = data.value();
+        if (scaleData.isBaby() == isBaby) {
+            return;
         }
+
+        scaleData.setBaby(isBaby);
+        scaleData.setScale(isBaby ? babyScaleFactor : 1.0f);
+
+        final FullMappings attributeMappings = rewriter.protocol().getMappingData().getAttributeMappings();
+        int attributeId = attributeMappings.mappedId("scale");
+        if (attributeId == -1) {
+            attributeId = attributeMappings.mappedId("generic.scale");
+            Preconditions.checkArgument(attributeId != -1);
+        }
+
+        final PacketWrapper attributesPacket = PacketWrapper.create(updateAttributesPacket, event.user());
+        attributesPacket.write(Types.VAR_INT, event.entityId());
+        attributesPacket.write(Types.VAR_INT, 1); // 1 attribute
+        attributesPacket.write(Types.VAR_INT, attributeId);
+        attributesPacket.write(Types.DOUBLE, (double) scaleData.scale());
+        attributesPacket.write(Types.VAR_INT, 0); // 0 modifiers
+        attributesPacket.send(rewriter.protocol().getClass());
     }
 }

--- a/common/src/main/java/com/viaversion/viabackwards/api/entities/EntityScaleHelper.java
+++ b/common/src/main/java/com/viaversion/viabackwards/api/entities/EntityScaleHelper.java
@@ -1,0 +1,126 @@
+/*
+ * This file is part of ViaBackwards - https://github.com/ViaVersion/ViaBackwards
+ * Copyright (C) 2016-2026 ViaVersion and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.viaversion.viabackwards.api.entities;
+
+
+import com.viaversion.viaversion.api.Via;
+import com.viaversion.viaversion.api.data.FullMappings;
+import com.viaversion.viaversion.api.data.entity.StoredEntityData;
+import com.viaversion.viaversion.api.minecraft.entities.EntityType;
+import com.viaversion.viaversion.api.minecraft.entitydata.EntityData;
+import com.viaversion.viaversion.api.protocol.Protocol;
+import com.viaversion.viaversion.api.protocol.packet.ClientboundPacketType;
+import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
+import com.viaversion.viaversion.api.type.Types;
+import com.viaversion.viaversion.rewriter.entitydata.EntityDataHandlerEvent;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A modular helper for injecting entity scaling on older clients via metadata interception.
+ * This helper listens for the isBaby metadata flag and injects an UPDATE_ATTRIBUTES packet
+ * to scale the entity, since older clients might not support the newer entity variants natively.
+ */
+public class EntityScaleHelper {
+
+    private static final class BabyScale {
+        private final float scaleFactor;
+        private final int index;
+
+        private BabyScale(float scaleFactor, int index) {
+            this.scaleFactor = scaleFactor;
+            this.index = index;
+        }
+    }
+
+    private final Map<EntityType, BabyScale> babyScales = new HashMap<>();
+    private final ClientboundPacketType updateAttributesPacket;
+
+    public EntityScaleHelper(ClientboundPacketType updateAttributesPacket) {
+        this.updateAttributesPacket = updateAttributesPacket;
+    }
+
+    /**
+     * Registers a scaling factor for a specific baby entity type.
+     * 
+     * @param type The entity type that requires scaling when it is a baby.
+     * @param babyScaleFactor The multiplier to apply to the minecraft:scale attribute when it is a baby.
+     * @param babyIndex The metadata index for the is_baby property in this specific protocol
+     */
+    public void addBabyScale(EntityType type, float babyScaleFactor, int babyIndex) {
+        babyScales.put(type, new BabyScale(babyScaleFactor, babyIndex));
+    }
+
+    public Iterable<EntityType> getRegisteredTypes() {
+        return babyScales.keySet();
+    }
+
+    /**
+     * Checks the metadata, tracks the scale state natively, and injects an UPDATE_ATTRIBUTES
+     * packet down the pipeline right as the metadata is processed by the client.
+     */
+    public void trackAndInject(final EntityDataHandlerEvent event, final EntityData data, final Protocol<?, ?, ?, ?> protocol) {
+        final StoredEntityData storedEntityData = event.user().getEntityTracker(protocol.getClass()).entityData(event.entityId());
+        if (storedEntityData == null) return;
+                  
+        final BabyScale babyScale = babyScales.get(storedEntityData.type());
+        if (babyScale == null || data.id() != babyScale.index || !(data.value() instanceof Boolean)) {
+            return;
+        }
+
+        EntityScaleData scaleData = storedEntityData.get(EntityScaleData.class);
+        if (scaleData == null) {
+            scaleData = new EntityScaleData();
+            storedEntityData.put(scaleData);
+        }
+        
+        final boolean isBaby = (Boolean) data.value();
+        final float scale = isBaby ? babyScale.scaleFactor : 1.0f;
+        
+        if (scaleData.isBaby() != isBaby || scaleData.scale() != scale) {
+            scaleData.setBaby(isBaby);
+            scaleData.setScale(scale);
+            
+            final FullMappings attributeMappings = protocol.getMappingData().getAttributeMappings();
+            if (attributeMappings == null) return;
+            
+            int unmappedId = attributeMappings.id("minecraft:scale");
+            if (unmappedId == -1) {
+                unmappedId = attributeMappings.id("minecraft:generic.scale");
+                if (unmappedId == -1) {
+                    unmappedId = attributeMappings.id("generic.scale");
+                }
+            }
+            
+            final int mappedId = unmappedId != -1 ? protocol.getMappingData().getNewAttributeId(unmappedId) : -1;
+            
+            if (mappedId != -1) {
+                final PacketWrapper updatePacket = PacketWrapper.create(updateAttributesPacket, event.user());
+                updatePacket.write(Types.VAR_INT, event.entityId());
+                updatePacket.write(Types.VAR_INT, 1); // 1 attribute
+                updatePacket.write(Types.VAR_INT, mappedId);
+                updatePacket.write(Types.DOUBLE, (double) scaleData.scale());
+                updatePacket.write(Types.VAR_INT, 0); // 0 modifiers
+                updatePacket.scheduleSend(protocol.getClass());
+            } else if (Via.getManager().isDebug()) {
+                protocol.getLogger().warning("Scale mapping not found for EntityScaleHelper, baby scaling won't be applied. It's harmless unless you're using custom mappings.");
+            }
+        }
+    }
+}

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_2to1_21/rewriter/EntityPacketRewriter1_21_2.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_2to1_21/rewriter/EntityPacketRewriter1_21_2.java
@@ -23,6 +23,7 @@ import com.viaversion.nbt.tag.IntTag;
 import com.viaversion.nbt.tag.ListTag;
 import com.viaversion.nbt.tag.Tag;
 import com.viaversion.viabackwards.ViaBackwards;
+import com.viaversion.viabackwards.api.entities.EntityScaleHelper;
 import com.viaversion.viabackwards.api.rewriters.EntityRewriter;
 import com.viaversion.viabackwards.protocol.v1_21_2to1_21.Protocol1_21_2To1_21;
 import com.viaversion.viabackwards.protocol.v1_21_2to1_21.storage.PlayerStorage;
@@ -637,6 +638,19 @@ public final class EntityPacketRewriter1_21_2 extends EntityRewriter<Clientbound
             VersionedTypes.V1_21.entityDataTypes.optionalComponentType
         );
         registerBlockStateHandler(EntityTypes1_21_2.ABSTRACT_MINECART, 11);
+
+        // Inject baby scaling for new entities mapped to old entities that don't have native baby variants
+        final EntityScaleHelper scaleHelper = new EntityScaleHelper(ClientboundPackets1_21.UPDATE_ATTRIBUTES);
+        final int WATER_CREATURE_BABY_INDEX = 16;
+        scaleHelper.addBabyScale(EntityTypes1_21_2.SQUID, 0.5f, WATER_CREATURE_BABY_INDEX);
+        scaleHelper.addBabyScale(EntityTypes1_21_2.GLOW_SQUID, 0.5f, WATER_CREATURE_BABY_INDEX);
+        scaleHelper.addBabyScale(EntityTypes1_21_2.DOLPHIN, 0.65f, WATER_CREATURE_BABY_INDEX);
+
+        for (final EntityType type : scaleHelper.getRegisteredTypes()) {
+            filter().type(type).handler((event, meta) -> {
+                scaleHelper.trackAndInject(event, meta, protocol);
+            });
+        }
 
         filter().type(EntityTypes1_21_2.CREAKING).cancel(17); // Active
         filter().type(EntityTypes1_21_2.CREAKING).cancel(16); // Can move

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_2to1_21/rewriter/EntityPacketRewriter1_21_2.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_2to1_21/rewriter/EntityPacketRewriter1_21_2.java
@@ -65,6 +65,7 @@ public final class EntityPacketRewriter1_21_2 extends EntityRewriter<Clientbound
     private static final int REL_DELTA_Y = 6;
     private static final int REL_DELTA_Z = 7;
     private static final int REL_ROTATE_DELTA = 8;
+    private static final int WATER_CREATURE_BABY_INDEX = 16;
     private boolean warned = ViaBackwards.getConfig().suppressEmulationWarnings();
 
     public EntityPacketRewriter1_21_2(final Protocol1_21_2To1_21 protocol) {
@@ -639,27 +640,20 @@ public final class EntityPacketRewriter1_21_2 extends EntityRewriter<Clientbound
         );
         registerBlockStateHandler(EntityTypes1_21_2.ABSTRACT_MINECART, 11);
 
-        // Inject baby scaling for new entities mapped to old entities that don't have native baby variants
-        final EntityScaleHelper scaleHelper = new EntityScaleHelper(ClientboundPackets1_21.UPDATE_ATTRIBUTES);
-        final int WATER_CREATURE_BABY_INDEX = 16;
-        scaleHelper.addBabyScale(EntityTypes1_21_2.SQUID, 0.5f, WATER_CREATURE_BABY_INDEX);
-        scaleHelper.addBabyScale(EntityTypes1_21_2.GLOW_SQUID, 0.5f, WATER_CREATURE_BABY_INDEX);
-        scaleHelper.addBabyScale(EntityTypes1_21_2.DOLPHIN, 0.65f, WATER_CREATURE_BABY_INDEX);
-
-        for (final EntityType type : scaleHelper.getRegisteredTypes()) {
-            filter().type(type).handler((event, meta) -> {
-                scaleHelper.trackAndInject(event, meta, protocol);
-            });
-        }
-
         filter().type(EntityTypes1_21_2.CREAKING).cancel(17); // Active
         filter().type(EntityTypes1_21_2.CREAKING).cancel(16); // Can move
 
         filter().type(EntityTypes1_21_2.ABSTRACT_BOAT).addIndex(11); // Boat type
         filter().type(EntityTypes1_21_2.SALMON).removeIndex(17); // Data type
-        filter().type(EntityTypes1_21_2.AGEABLE_WATER_CREATURE).removeIndex(16); // Baby
 
         filter().type(EntityTypes1_21_2.ABSTRACT_ARROW).removeIndex(10); // In ground
+
+        final EntityScaleHelper scaleHelper = new EntityScaleHelper(this, ClientboundPackets1_21.UPDATE_ATTRIBUTES);
+        scaleHelper.addBabyScale(EntityTypes1_21_2.SQUID, 0.5f, WATER_CREATURE_BABY_INDEX);
+        scaleHelper.addBabyScale(EntityTypes1_21_2.GLOW_SQUID, 0.5f, WATER_CREATURE_BABY_INDEX);
+        scaleHelper.addBabyScale(EntityTypes1_21_2.DOLPHIN, 0.65f, WATER_CREATURE_BABY_INDEX);
+
+        filter().type(EntityTypes1_21_2.AGEABLE_WATER_CREATURE).removeIndex(WATER_CREATURE_BABY_INDEX);
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_6to1_21_5/rewriter/EntityPacketRewriter1_21_6.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_6to1_21_5/rewriter/EntityPacketRewriter1_21_6.java
@@ -17,6 +17,7 @@
  */
 package com.viaversion.viabackwards.protocol.v1_21_6to1_21_5.rewriter;
 
+import com.viaversion.viabackwards.api.entities.EntityScaleHelper;
 import com.viaversion.viabackwards.api.rewriters.EntityRewriter;
 import com.viaversion.viabackwards.protocol.v1_21_6to1_21_5.Protocol1_21_6To1_21_5;
 import com.viaversion.viaversion.api.minecraft.entities.EntityType;
@@ -98,6 +99,20 @@ public final class EntityPacketRewriter1_21_6 extends EntityRewriter<Clientbound
         filter().type(EntityTypes1_21_6.HANGING_ENTITY).removeIndex(8); // Direction
         filter().type(EntityTypes1_21_6.HAPPY_GHAST).cancel(17); // Leash holder
         filter().type(EntityTypes1_21_6.HAPPY_GHAST).cancel(18); // Stays still
+
+        // Inject baby scaling for new entities mapped to old entities that don't have native baby variants
+        final EntityScaleHelper scaleHelper = new EntityScaleHelper(ClientboundPackets1_21_5.UPDATE_ATTRIBUTES);
+        final int GHAST_BABY_INDEX = 16;
+        // Scale 0.2375 reduces the 4.0x4.0 Ghast hitbox to roughly 0.95x0.95 (approx 1x1) for the Ghastling
+        scaleHelper.addBabyScale(EntityTypes1_21_6.HAPPY_GHAST, 0.2375f, GHAST_BABY_INDEX);
+
+        for (final EntityType type : scaleHelper.getRegisteredTypes()) {
+            filter().type(type).handler((event, meta) -> {
+                scaleHelper.trackAndInject(event, meta, protocol);
+            });
+        }
+
+        filter().type(EntityTypes1_21_6.HAPPY_GHAST).cancel(16); // Cancel isBaby to prevent Ghast 'attacking' face
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_6to1_21_5/rewriter/EntityPacketRewriter1_21_6.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_6to1_21_5/rewriter/EntityPacketRewriter1_21_6.java
@@ -100,19 +100,10 @@ public final class EntityPacketRewriter1_21_6 extends EntityRewriter<Clientbound
         filter().type(EntityTypes1_21_6.HAPPY_GHAST).cancel(17); // Leash holder
         filter().type(EntityTypes1_21_6.HAPPY_GHAST).cancel(18); // Stays still
 
-        // Inject baby scaling for new entities mapped to old entities that don't have native baby variants
-        final EntityScaleHelper scaleHelper = new EntityScaleHelper(ClientboundPackets1_21_5.UPDATE_ATTRIBUTES);
-        final int GHAST_BABY_INDEX = 16;
         // Scale 0.2375 reduces the 4.0x4.0 Ghast hitbox to roughly 0.95x0.95 (approx 1x1) for the Ghastling
-        scaleHelper.addBabyScale(EntityTypes1_21_6.HAPPY_GHAST, 0.2375f, GHAST_BABY_INDEX);
-
-        for (final EntityType type : scaleHelper.getRegisteredTypes()) {
-            filter().type(type).handler((event, meta) -> {
-                scaleHelper.trackAndInject(event, meta, protocol);
-            });
-        }
-
-        filter().type(EntityTypes1_21_6.HAPPY_GHAST).cancel(16); // Cancel isBaby to prevent Ghast 'attacking' face
+        final EntityScaleHelper scaleHelper = new EntityScaleHelper(this, ClientboundPackets1_21_5.UPDATE_ATTRIBUTES);
+        scaleHelper.addBabyScale(EntityTypes1_21_6.HAPPY_GHAST, 0.2375f, 16);
+        filter().type(EntityTypes1_21_6.HAPPY_GHAST).cancel(16); // Charging for regular ghasts
     }
 
     @Override


### PR DESCRIPTION
Resubmitting for feature request #1058 

I gave another go of the baby mob scaling, it was much easier using the SharedRegistrations system, and as discussed, minimized impact by making sure to use the filter by type framework to just check for registered mobs (Happy Ghast, Squids, Dolphin). I tied the packet injection strictly to state-changes, unlike the previous PR that more globally hooked to `UPDATE_ATTRIBUTES`. So, this should really minimize overhead on the network thread.

I still felt this was important, for the Ghastling's hitbox, both for jumping on, and matching the server physics, because when one flies to the player with a snowball, it currently has this jittery rubber-banding interaction where the client thinks the 4x4x4 version is pushing the player away, but the server has to reset them back. 

## Changes

-  New `EntityScaleHelper` in `api/entities` -- a dedicated listener for the metadata, rather than a global packet hook.
- Updated protocol rewriters to explicitly register the entities we care about & their scale factors.
- When the baby metadata is seen, the helper calculates the scale, compares it to the tracked `EntityScaleData`, and dynamically injects an `UPDATE_ATTRIBUTES` packet into the pipeline to shrink the mob.
- Also added `cancel(16)`, hard-coded that because it's a known Ghast attribute, in `EntityPacketRewriter1_21_6` for the Happy Ghast so older clients don't keep showing the Ghast's "is attacking" fireball face.

  I know the preference is to attach attributes during `SPAWN_ENTITY`. But the baby state of these mobs is entirely dictated by the `isBaby` metadata (e.g., index 16 for HGs). Because `SPAWN_ENTITY` doesn't have metadata, I couldn't find a way to know its baby state until its first `ENTITY_DATA` packet. Injecting the attribute update at the exact moment the metadata is parsed seemed like the most non-intrusive way to guarantee the scale applies.

## Manual testing
- **Paper 1.21.11 Server**:
  - Connected with **1.21.5 client** and verified Happy Ghast baby scaling works perfectly via the new metadata injection.
  - Connected with **1.20.5 client** and verified Squids & Dolphin scaling behaves flawlessly.
  - Hitboxes correctly shrink to match the server physics, completely eliminating the rubber-banding interaction desyncs.
  - Ghastlings don't have the fireball face.
<img width="854" height="480" alt="2026-05-27_09 39 30" src="https://github.com/user-attachments/assets/9f5f9549-f2ff-456f-86b7-15094c421493" />
<img width="854" height="480" alt="2026-02-25_04 16 56" src="https://github.com/user-attachments/assets/f76c8414-f0da-46eb-a103-ed8259f3a520" />


