### PR TITLE
Don't send legacy clients their own death event

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_14to1_13_2/rewriter/EntityPacketRewriter1_14.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_14to1_13_2/rewriter/EntityPacketRewriter1_14.java
@@ -64,6 +64,12 @@ public class EntityPacketRewriter1_14 extends LegacyEntityRewriter<ClientboundPa
             if (status != 3) return;
 
             EntityTracker tracker = tracker(wrapper.user());
+            if (entityId == tracker.clientEntityId()) {
+                // Clients up to 1.13.2 run the local death handling on their own death event, clearing
+                // their own inventory; the death screen still shows from the health update
+                wrapper.cancel();
+                return;
+            }
             EntityType entityType = tracker.entityType(entityId);
             if (entityType != EntityTypes1_14.PLAYER) return;
 


### PR DESCRIPTION
Clients up to 1.13.2 run the local death handling on their own entity death event, clearing their own inventory client-side (most visibly an emptied hotbar on the death screen, since modern servers don't resync the inventory on death). The death screen still shows from the health update. 1.14+ clients no longer clear the inventory.