### PR TITLE
Prevent Mannequin names from having formatting in 1.12.2

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_9to1_21_7/rewriter/EntityPacketRewriter1_21_9.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_9to1_21_7/rewriter/EntityPacketRewriter1_21_9.java
@@ -315,10 +315,11 @@ public final class EntityPacketRewriter1_21_9 extends EntityRewriter<Clientbound
         final StringBuilder builder = new StringBuilder();
         // Player names cannot be updated after the initial add without fully respawning them;
         // Stack random color codes to appear as an empty name, later filled with a team prefix
-        for (int i = 0; i < 8; i++) {
+        for (int i = 0; i < 7; i++) {
             final int random = ThreadLocalRandom.current().nextInt(ChatColorUtil.ALL_CODES.length());
             builder.append('§').append(ChatColorUtil.ALL_CODES.charAt(random));
         }
+        builder.append("§r");
         return builder.toString();
     }
 


### PR DESCRIPTION
Prevents random text formatting from leaking into the Mannequin names for clients on 1.12.2 and below:
<img width="448" height="389" alt="image" src="https://github.com/user-attachments/assets/0d2aaffd-5602-4495-bc55-2bbda87dbcd9" />
