### PR TITLE
Don't always send dummy respawn

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_16to1_15_2/rewriter/EntityPacketRewriter1_16.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_16to1_15_2/rewriter/EntityPacketRewriter1_16.java
@@ -113,18 +113,6 @@ public class EntityPacketRewriter1_16 extends EntityRewriter<ClientboundPackets1
                     ClientWorld clientWorld = storables.clientWorld();
                     int dimension = wrapper.get(Types.INT, 0);
 
-                    // Send a dummy respawn with a different dimension if the world name was different and the same dimension was used
-                    if (clientWorld.getEnvironment() != null && dimension == clientWorld.getEnvironment().id()
-                        && (wrapper.user().isClientSide() || Via.getPlatform().isProxy()
-                        || wrapper.user().getProtocolInfo().protocolVersion().olderThanOrEqualTo(ProtocolVersion.v1_12_2) // Hotfix for https://github.com/ViaVersion/ViaBackwards/issues/381
-                        || !nextWorldName.equals(worldNameTracker.getWorldName()))) {
-                        PacketWrapper packet = wrapper.create(ClientboundPackets1_15.RESPAWN);
-                        packet.write(Types.INT, dimension == 0 ? -1 : 0);
-                        packet.write(Types.LONG, 0L);
-                        packet.write(Types.UNSIGNED_BYTE, (short) 0);
-                        packet.write(Types.STRING, "default");
-                        packet.send(Protocol1_16To1_15_2.class);
-                    }
 
                     if (clientWorld.setEnvironment(dimension)) {
                         tracker(wrapper.user()).clearEntities();
@@ -138,6 +126,20 @@ public class EntityPacketRewriter1_16 extends EntityRewriter<ClientboundPackets1
 
                     final PlayerAttributesStorage attributes = storables.playerAttributesStorage();
                     final boolean keepPlayerAttributes = wrapper.read(Types.BOOLEAN);
+
+                    // Send a dummy respawn with a different dimension if the world name was different and the same dimension was used
+                    if ((clientWorld.getEnvironment() != null && dimension == clientWorld.getEnvironment().id())
+                        && (!keepPlayerAttributes
+                        || !nextWorldName.equalsIgnoreCase(worldNameTracker.getWorldName())
+                        || (wrapper.user().isClientSide() && !Via.getPlatform().isProxy()))) {
+                        PacketWrapper packet = wrapper.create(ClientboundPackets1_15.RESPAWN);
+                        packet.write(Types.INT, dimension == 0 ? -1 : 0);
+                        packet.write(Types.LONG, 0L);
+                        packet.write(Types.UNSIGNED_BYTE, (short) 0);
+                        packet.write(Types.STRING, "default");
+                        packet.send(Protocol1_16To1_15_2.class);
+                    }
+
                     if (keepPlayerAttributes) {
                         // Ensure packet order
                         wrapper.send(Protocol1_16To1_15_2.class);


### PR DESCRIPTION
Should fix a regression introduced by https://github.com/ViaVersion/ViaBackwards/commit/29d3787de843734e2dfbb869a14117ba119b1fd0, forcing keep attributes respawns to work like non-keep attribute respawns, causing the client to forget chunks & the server to not resend them, [leading to hacky workarounds like this](https://github.com/SkinsRestorer/SkinsRestorer/blob/dev/multiver/viaversion/src/main/java/net/skinsrestorer/viaversion/ViaWorkaround.java) (good thing it doesn't run on Velocity proxies, or otherwise I wouldn't have figured this out :P).

Keep attribute respawns are invoked when a Paper plugin makes a change to a player's profile (for example, changing their skin).

In theory, world changes should always be non-keep attribute respawns, but I kept the old world name check just in-case my assumption is wrong and causes another regression.

I don't know if this is the best fix, but I have tested it and am unable to reproduce #381 with this patch applied or what the comment describes.