### PR TITLE
Handle environment attributes in timelines on the 26.1->1.21.11 step

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v26_1to1_21_11/Protocol26_1To1_21_11.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v26_1to1_21_11/Protocol26_1To1_21_11.java
@@ -87,14 +87,8 @@ public final class Protocol26_1To1_21_11 extends BackwardsProtocol<ClientboundPa
         super.registerPackets();
 
         // Remove new environment attributes
-        registryDataRewriter.addHandler("dimension_type", (key, tag) -> {
-            final CompoundTag attributes = tag.getCompoundTag("attributes");
-            if (attributes != null) {
-                removeNamespaced(attributes, "visual/block_light_tint");
-                removeNamespaced(attributes, "visual/night_vision_color");
-                removeNamespaced(attributes, "visual/ambient_light_color");
-            }
-        });
+        registryDataRewriter.addHandler("dimension_type", (key, tag) -> removeEnvironmentAttributes(tag.getCompoundTag("attributes")));
+        registryDataRewriter.addHandler("timeline", (key, tag) -> removeEnvironmentAttributes(tag.getCompoundTag("tracks")));
 
         // Move around entity variant names and sounds
         registryDataRewriter.addHandler("wolf_sound_variant", (key, tag) -> {
@@ -151,6 +145,15 @@ public final class Protocol26_1To1_21_11 extends BackwardsProtocol<ClientboundPa
             wrapper.write(Types.LONG, dayTime);
             wrapper.write(Types.BOOLEAN, advanceTime);
         });
+    }
+
+    private void removeEnvironmentAttributes(final CompoundTag tag) {
+        if (tag == null) {
+            return;
+        }
+        removeNamespaced(tag, "visual/block_light_tint");
+        removeNamespaced(tag, "visual/night_vision_color");
+        removeNamespaced(tag, "visual/ambient_light_color");
     }
 
     private void removeEntityNamePrefix(final String key, final CompoundTag tag) {


### PR DESCRIPTION
Environment attributes added in 26.1 were being filtered from dimension types in the 26.1->1.21.11 step, but the ones in timelines were not. This caused 1.21.11 client connections to fail for 26.1+ servers if a timeline containing one of the environment attributes were present.