### PR TITLE
Rewrite cat to ocelot variants in 1.14->1.13.2

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_14to1_13_2/rewriter/EntityPacketRewriter1_14.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_14to1_13_2/rewriter/EntityPacketRewriter1_14.java
@@ -499,8 +499,6 @@ public class EntityPacketRewriter1_14 extends LegacyEntityRewriter<ClientboundPa
                     default -> 0; // Untamed
                 } : 0;
                 data.setValue(ocelotVariant);
-            } else if (event.index() == 13) {
-                data.setValue((byte) ((byte) data.getValue() & 0x4));
             }
         });
 

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_14to1_13_2/rewriter/EntityPacketRewriter1_14.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_14to1_13_2/rewriter/EntityPacketRewriter1_14.java
@@ -484,7 +484,21 @@ public class EntityPacketRewriter1_14 extends LegacyEntityRewriter<ClientboundPa
 
         filter().type(EntityTypes1_14.CAT).handler((event, data) -> {
             if (event.index() == 15) {
-                data.setValue(1);
+                Integer catVariant = data.value();
+                int ocelotVariant = catVariant != null ? switch (catVariant) {
+                    // new ocelot mappings
+                    case 0, 1, 2, 3 -> catVariant;
+
+                    // Map to tuxedo
+                    case 10 -> 1; // all_black
+                    // Map to red
+                    case 5, 6 -> 2; // calico, persian
+                    // Map to siamese
+                    case 4, 7, 8, 9 -> 3; // british_shorthair, ragdoll, white, jellie
+
+                    default -> 0; // Untamed
+                } : 0;
+                data.setValue(ocelotVariant);
             } else if (event.index() == 13) {
                 data.setValue((byte) ((byte) data.getValue() & 0x4));
             }


### PR DESCRIPTION
Makes ocelots look more colorful in 1.13.2 and below instead of always being black (or untamed for 1.14 ocelots)