### PR TITLE
Mannequin name improvements for 1.21.9->1.21.7

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_9to1_21_7/rewriter/EntityPacketRewriter1_21_9.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_9to1_21_7/rewriter/EntityPacketRewriter1_21_9.java
@@ -95,7 +95,7 @@ public final class EntityPacketRewriter1_21_9 extends EntityRewriter<Clientbound
                 final TrackedEntity trackedEntity = tracker(wrapper.user()).entity(entityId);
 
                 trackedEntity.put(mannequinData);
-                sendInitialPlayerInfoUpdate(wrapper.user(), mannequinData, new GameProfile.Property[0]);
+                sendInitialPlayerInfoUpdate(wrapper.user(), mannequinData, new GameProfile.Property[0], false);
 
                 mannequinData.setPosition(x, y, z);
                 mannequinData.setRotation(yaw, pitch);
@@ -255,7 +255,8 @@ public final class EntityPacketRewriter1_21_9 extends EntityRewriter<Clientbound
         }
     }
 
-    private void sendInitialPlayerInfoUpdate(final UserConnection connection, final MannequinData mannequinData, final GameProfile.Property[] properties) {
+    private void sendInitialPlayerInfoUpdate(final UserConnection connection, final MannequinData mannequinData,
+                                             final GameProfile.Property[] properties, final boolean registerTeam) {
         final PacketWrapper playerInfo = PacketWrapper.create(ClientboundPackets1_21_6.PLAYER_INFO_UPDATE, connection);
 
         final BitSet actions = new BitSet(8);
@@ -276,7 +277,9 @@ public final class EntityPacketRewriter1_21_9 extends EntityRewriter<Clientbound
         playerInfo.write(Types.BOOLEAN, true); // Show hat
         playerInfo.send(Protocol1_21_9To1_21_7.class);
 
-        sendPlayerTeamDisplayName(connection, mannequinData, mannequinData.displayName());
+        if (registerTeam) {
+            sendPlayerTeamDisplayName(connection, mannequinData, mannequinData.displayName());
+        }
     }
 
     private void sendPlayerInfoDisplayNameUpdate(final UserConnection connection, final MannequinData mannequinData, @Nullable final Tag displayName) {
@@ -294,16 +297,16 @@ public final class EntityPacketRewriter1_21_9 extends EntityRewriter<Clientbound
 
     private void sendPlayerTeamDisplayName(final UserConnection connection, final MannequinData mannequinData, final Tag displayName) {
         // Send the display name as a team prefix
-        final Tag nonNullDisplayName = displayName != null ? displayName : new StringTag("Mannequin");
+        boolean showName = displayName != null && (!(displayName instanceof StringTag str) || !str.getValue().isEmpty());
         final PacketWrapper addTeam = PacketWrapper.create(ClientboundPackets1_21_6.SET_PLAYER_TEAM, connection);
         addTeam.write(Types.STRING, mannequinData.name());
         addTeam.write(Types.BYTE, mannequinData.hasTeam() ? (byte) 2 : 0); // Mode
-        addTeam.write(Types.TRUSTED_TAG, nonNullDisplayName); // Display Name
+        addTeam.write(Types.TRUSTED_TAG, displayName != null ? displayName : new StringTag("Mannequin")); // Display Name
         addTeam.write(Types.BYTE, (byte) 0); // Flags
-        addTeam.write(Types.VAR_INT, 0); // Nametag visibility
+        addTeam.write(Types.VAR_INT, showName ? 0 : 1); // Nametag visibility
         addTeam.write(Types.VAR_INT, 0); // Collision rule
         addTeam.write(Types.VAR_INT, 15); // Color
-        addTeam.write(Types.TRUSTED_TAG, nonNullDisplayName); // Prefix
+        addTeam.write(Types.TRUSTED_TAG, displayName != null ? displayName : new StringTag("")); // Prefix
         addTeam.write(Types.TRUSTED_TAG, new StringTag("")); // Suffix
         if (!mannequinData.hasTeam()) {
             addTeam.write(Types.STRING_ARRAY, new String[]{mannequinData.name()});
@@ -410,7 +413,10 @@ public final class EntityPacketRewriter1_21_9 extends EntityRewriter<Clientbound
                 playerInfoRemove.send(Protocol1_21_9To1_21_7.class);
 
                 // Spawn new entity
-                sendInitialPlayerInfoUpdate(event.user(), mannequinData, profile.profile().properties());
+                if (profile.profile().name() != null) {
+                    mannequinData.setName(profile.profile().name());
+                }
+                sendInitialPlayerInfoUpdate(event.user(), mannequinData, profile.profile().properties(), true);
 
                 final PacketWrapper spawnEntityPacket = PacketWrapper.create(ClientboundPackets1_21_6.ADD_ENTITY, event.user());
                 spawnEntityPacket.write(Types.VAR_INT, event.entityId());

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_9to1_21_7/storage/MannequinData.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21_9to1_21_7/storage/MannequinData.java
@@ -30,7 +30,7 @@ import java.util.UUID;
 
 public final class MannequinData implements StorableObject {
     private final UUID uuid;
-    private final String name;
+    private String name;
     private boolean hasTeam;
 
 
@@ -83,6 +83,10 @@ public final class MannequinData implements StorableObject {
 
     public void setPassengers(final int[] passengers) {
         this.passengers = passengers;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     public double x() {


### PR DESCRIPTION
This slightly changes the way mannequin names are handled:

* When spawning the second entity, the new name from the profile is now used to name the player info entry. This is nice because it allows registering the mannequin in scoreboard teams.
* Team registration is only performed when the second entity is spawned, this is because the mannequin's name can change in-between due to the above. Perhaps I could also add a way to disable this, because in some cases (I'd imagine on track/untrack) it may override the team set by the server/plugins?
* When the mannequin has no `CustomName`, its nametag is hidden (by setting the option in its team), which matches 1.21.9+ behavior. Technically in 1.21.9 this depends on `CustomNameVisible` (otherwise the name can display but only on hover), not sure whether I should change it to match that, because in 1.8 and 1.9 the name is either always displayed or always hidden.

I also wanted to remove them from tablist after spawning (for versions that don't have the Listed flag, primarily 1.8) to match the vanilla behavior. Unfortunately, this has to be handled by server implementations because the vanilla 1.8 client needs to render the player at least once to save its skin (amazing implementation), which means the player info remove packet has to be delayed slightly.