### PR TITLE
Fix default painting handling in 1.19.4+

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_19_4to1_19_3/Protocol1_19_4To1_19_3.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_19_4to1_19_3/Protocol1_19_4To1_19_3.java
@@ -24,10 +24,15 @@ import com.viaversion.viabackwards.protocol.v1_19_4to1_19_3.rewriter.BlockItemPa
 import com.viaversion.viabackwards.protocol.v1_19_4to1_19_3.rewriter.ComponentRewriter1_19_4;
 import com.viaversion.viabackwards.protocol.v1_19_4to1_19_3.rewriter.EntityPacketRewriter1_19_4;
 import com.viaversion.viabackwards.protocol.v1_19_4to1_19_3.storage.EntityTracker1_19_4;
+import com.viaversion.viabackwards.protocol.v1_19_4to1_19_3.storage.LinkedEntityStorage;
+import com.viaversion.viabackwards.protocol.v1_21to1_20_5.storage.EnchantmentsPaintingsStorage;
 import com.viaversion.viaversion.api.connection.UserConnection;
+import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_19_4;
+import com.viaversion.viaversion.api.minecraft.entitydata.EntityData;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.chunk.ChunkType1_18;
+import com.viaversion.viaversion.api.type.types.version.Types1_19_3;
 import com.viaversion.viaversion.libs.gson.JsonElement;
 import com.viaversion.viaversion.protocols.v1_19_1to1_19_3.packet.ClientboundPackets1_19_3;
 import com.viaversion.viaversion.protocols.v1_19_1to1_19_3.packet.ServerboundPackets1_19_3;
@@ -38,7 +43,10 @@ import com.viaversion.viaversion.rewriter.BlockRewriter;
 import com.viaversion.viaversion.rewriter.CommandRewriter;
 import com.viaversion.viaversion.rewriter.ParticleRewriter;
 import com.viaversion.viaversion.rewriter.TagRewriter;
+
+import java.util.ArrayList;
 import java.util.Base64;
+import java.util.List;
 
 public final class Protocol1_19_4To1_19_3 extends BackwardsProtocol<ClientboundPackets1_19_4, ClientboundPackets1_19_3, ServerboundPackets1_19_4, ServerboundPackets1_19_3> {
 
@@ -87,7 +95,33 @@ public final class Protocol1_19_4To1_19_3 extends BackwardsProtocol<ClientboundP
             wrapper.write(Types.OPTIONAL_STRING, iconBase64);
         });
 
-        cancelClientbound(ClientboundPackets1_19_4.BUNDLE_DELIMITER);
+        registerClientbound(ClientboundPackets1_19_4.BUNDLE_DELIMITER, null, wrapper -> {
+            // Bundles were introduced in 1.19.4
+            wrapper.cancel();
+
+            // 1.19.3+ only sends non-default values, 1.19->1.18 protocol needs entity data to spawn paintings.
+            // In 1.19.4 we can detect this because add_entity + set_entity_data are always sent in a bundle
+            EntityTracker1_19_4 tracker = wrapper.user().getEntityTracker(this);
+            if (tracker.getSpawningPainting() != -1 && tracker.entityType(tracker.getSpawningPainting()) == EntityTypes1_19_4.PAINTING) {
+                final int paintingId = tracker.getSpawningPainting();
+                final LinkedEntityStorage storage = tracker.linkedEntityStorage(paintingId);
+                if (storage != null && !storage.sentPaintingType()) {
+                    // Use first type in registry as default, kebab (0) otherwise.
+                    // kebab has been the default painting for most versions, 1.21+ uses alban instead but probably
+                    // unintentionally (first in registry)
+                    final EnchantmentsPaintingsStorage registry = wrapper.user().get(EnchantmentsPaintingsStorage.class);
+                    final int defaultPainting = registry != null ? registry.mappedDefaultPainting() : 0;
+                    final EntityData type = new EntityData(8, Types1_19_3.ENTITY_DATA_TYPES.paintingVariantType, defaultPainting);
+
+                    final PacketWrapper packet = PacketWrapper.create(ClientboundPackets1_19_3.SET_ENTITY_DATA, wrapper.user());
+                    packet.write(Types.VAR_INT, paintingId);
+                    packet.write(Types1_19_3.ENTITY_DATA_LIST, List.of(type));
+                    packet.send(Protocol1_19_4To1_19_3.class);
+                }
+            }
+            tracker.setSpawningPainting(-1);
+        });
+
         cancelClientbound(ClientboundPackets1_19_4.CHUNKS_BIOMES); // We definitely do not want to cache every single chunk just to resent them with new biomes
     }
 

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_19_4to1_19_3/rewriter/EntityPacketRewriter1_19_4.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_19_4to1_19_3/rewriter/EntityPacketRewriter1_19_4.java
@@ -105,6 +105,13 @@ public final class EntityPacketRewriter1_19_4 extends EntityRewriter<Clientbound
                         wrapper.set(Types.VAR_INT, 2, protocol.getMappingData().getNewBlockStateId(blockState));
                     }
 
+                    final EntityTracker1_19_4 tracker = wrapper.user().getEntityTracker(protocol);
+                    if (entity.entityType() == EntityTypes1_19_4.PAINTING) {
+                        tracker.setSpawningPainting(entityId);
+                    } else {
+                        tracker.setSpawningPainting(-1);
+                    }
+
                     final LinkedEntityStorage storage = new LinkedEntityStorage();
                     final double x = wrapper.get(Types.DOUBLE, 0);
                     final double z = wrapper.get(Types.DOUBLE, 2);
@@ -491,6 +498,14 @@ public final class EntityPacketRewriter1_19_4 extends EntityRewriter<Clientbound
             // Remove a large heap of display entity data
             if (event.index() > 7) {
                 event.cancel();
+            }
+        });
+
+        filter().type(EntityTypes1_19_4.PAINTING).index(8).handler((event, data) -> {
+            // Painting variant
+            final LinkedEntityStorage storage = event.trackedEntity().get(LinkedEntityStorage.class);
+            if (storage != null) {
+                storage.sentPaintingType(true);
             }
         });
 

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_19_4to1_19_3/storage/EntityTracker1_19_4.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_19_4to1_19_3/storage/EntityTracker1_19_4.java
@@ -35,6 +35,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class EntityTracker1_19_4 extends EntityTrackerBase {
 
     private final IntSet generatedEntities = new IntOpenHashSet(); // Track entities spawned to prevent duplicated entity ids
+    private int spawningPainting = -1;
 
     public EntityTracker1_19_4(final UserConnection connection) {
         super(connection, EntityTypes1_19_4.PLAYER);
@@ -60,6 +61,16 @@ public final class EntityTracker1_19_4 extends EntityTrackerBase {
 
         addEntity.send(Protocol1_19_4To1_19_3.class);
         return entityId;
+    }
+
+
+
+    public void setSpawningPainting(int spawningPainting) {
+        this.spawningPainting = spawningPainting;
+    }
+
+    public int getSpawningPainting() {
+        return spawningPainting;
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_19_4to1_19_3/storage/LinkedEntityStorage.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_19_4to1_19_3/storage/LinkedEntityStorage.java
@@ -31,6 +31,7 @@ public class LinkedEntityStorage extends EntityPositionStorage implements Storab
     private int[] entities;
     private int[] passengers;
     private Integer vehicleId;
+    private boolean sentPaintingType;
 
     public int @Nullable [] entities() {
         return entities;
@@ -58,6 +59,14 @@ public class LinkedEntityStorage extends EntityPositionStorage implements Storab
 
     public void setVehicleId(@Nullable final Integer vehicleId) {
         this.vehicleId = vehicleId;
+    }
+
+    public boolean sentPaintingType() {
+        return sentPaintingType;
+    }
+
+    public void sentPaintingType(boolean sentPaintingType) {
+        this.sentPaintingType = sentPaintingType;
     }
 
     public void remove(final UserConnection connection) {

--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21to1_20_5/storage/EnchantmentsPaintingsStorage.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v1_21to1_20_5/storage/EnchantmentsPaintingsStorage.java
@@ -58,7 +58,11 @@ public final class EnchantmentsPaintingsStorage implements StorableObject {
     }
 
     public int mappedPainting(final int id) {
-        return id > 0 && id < paintingMappings.length ? paintingMappings[id] : 0;
+        return id >= 0 && id < paintingMappings.length ? paintingMappings[id] : 0;
+    }
+
+    public int mappedDefaultPainting() {
+        return mappedPainting(0);
     }
 
     public @Nullable Tag enchantmentDescription(final int id) {


### PR DESCRIPTION
This fixes the following issues:

* In 1.21+ servers, the Albanian (`alban`) painting would:
  * spawn as Kebab when placed, and not spawn upon reload (in 1.18.2 or older clients)
  * spawn as Kebab (in 1.19 and above)  
* In 1.19.3-1.20.6 servers, the Kebab painting would not spawn for 1.18.2 or older clients. 
 
(Unfortunately, the implementation leaves 1.19.3 servers affected)

See also [this reply](https://github.com/ViaVersion/ViaBackwards/pull/1313#issuecomment-5546127007).

In 1.19.3+, default values for entity data are no longer sent. The 1.19->1.18.2 rewriter waits to receive the painting type data before sending `add_painting`, so it needs to be sent manually. 1.19.4 added bundles, and `add_entity` is always followed by `set_entity_data` in a bundle ([reference](https://mcsrc.dev/2/1.19.4/net/minecraft/server/level/ServerEntity#L217)), so this can be used to detect whether no entity data packet was sent.

When that's the case, the implementation sends the default type manually. The default type seemingly changed with 1.21, previously it was `kebab` in all versions (see e.g. https://mcsrc.dev/2/1.19/net/minecraft/world/entity/decoration/Painting#L35), but in 1.21 there is no explicit default set, and the first type in the registry is used instead. Currently, this means `alban` is the new default (you can test this by running `/summon painting ~ ~ ~`). So this PR also fixes that painting spawning as kebab in newer clients.
