### PR TITLE
 Assert nullable of predicate on 26.2 -> 26.1

### DIFF
--- a/common/src/main/java/com/viaversion/viabackwards/protocol/v26_2to26_1/Protocol26_2To26_1.java
+++ b/common/src/main/java/com/viaversion/viabackwards/protocol/v26_2to26_1/Protocol26_2To26_1.java
@@ -74,9 +74,12 @@ public final class Protocol26_2To26_1 extends BackwardsProtocol<ClientboundPacke
             final String condition = term.getString("condition");
             if (Key.equals(condition, "entity_properties")) {
                 final CompoundTag predicate = term.getCompoundTag("predicate");
-                final Tag typeTag = predicate.remove("entity_type");
-                if (typeTag != null) {
-                    predicate.put("type", typeTag);
+
+                if (predicate != null) {
+                    final Tag typeTag = predicate.remove("entity_type");
+                    if (typeTag != null) {
+                        predicate.put("type", typeTag);
+                    }
                 }
             }
         }


### PR DESCRIPTION
predicate can be null, and then .remove() causes an error when joining from older clients